### PR TITLE
[Enhancement] Enable ordinal aggregation in aggregation layer (hex, grid, cluster)

### DIFF
--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -50,7 +50,7 @@ class App extends Component {
 
   componentDidMount() {
     // load sample data
-    // this._loadSampleData();
+    this._loadSampleData();
   }
 
   _loadSampleData() {
@@ -85,31 +85,31 @@ class App extends Component {
     );
 
     // load icon data and config and process csv file
-    this.props.dispatch(
-      addDataToMap({
-        datasets: [
-          {
-            info: {
-              label: 'Icon Data',
-              id: 'test_icon_data'
-            },
-            data: Processors.processCsvData(sampleIconCsv)
-          }
-        ],
-        options: {
-          centerMap: false
-        },
-        config: savedMapConfig
-      })
-    );
+    // this.props.dispatch(
+    //   addDataToMap({
+    //     datasets: [
+    //       {
+    //         info: {
+    //           label: 'Icon Data',
+    //           id: 'test_icon_data'
+    //         },
+    //         data: Processors.processCsvData(sampleIconCsv)
+    //       }
+    //     ],
+    //     options: {
+    //       centerMap: false
+    //     },
+    //     config: savedMapConfig
+    //   })
+    // );
 
     // load geojson
-    this.props.dispatch(
-      updateVisData({
-        info: {label: 'SF Zip Geo'},
-        data: Processors.processGeojson(sampleGeojson)
-      })
-    );
+    // this.props.dispatch(
+    //   updateVisData({
+    //     info: {label: 'SF Zip Geo'},
+    //     data: Processors.processGeojson(sampleGeojson)
+    //   })
+    // );
   }
 
   render() {

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -49,7 +49,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    // load trip based data with config
+    // load sample data
     // this._loadSampleData();
   }
 

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -96,8 +96,8 @@ const getQuantLegends = (scale, labelFormat) => {
 export default class ColorLegend extends Component {
   static propTypes = {
     width: PropTypes.number.isRequired,
-    scaleType: PropTypes.string.isRequired,
-    domain: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+    scaleType: PropTypes.string,
+    domain: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     fieldType: PropTypes.string,
     range: PropTypes.arrayOf(PropTypes.string),
     labelFormat: PropTypes.func

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -39,7 +39,7 @@ const StyledLegend = styled.div`
   ${props => props.theme.sidePanelScrollBar};
 
   max-height: 150px;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   svg {
     text {

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -39,7 +39,7 @@ const StyledLegend = styled.div`
   ${props => props.theme.sidePanelScrollBar};
 
   max-height: 150px;
-  overflow-y: auto;
+  overflow-y: scroll;
 
   svg {
     text {

--- a/src/components/common/field-selector.js
+++ b/src/components/common/field-selector.js
@@ -69,6 +69,7 @@ export default class FieldSelector extends Component {
     value: FieldType,
     filterFieldTypes: PropTypes.oneOfType([FieldType, PropTypes.arrayOf(FieldType)]),
     inputTheme: PropTypes.string,
+    placeholder: PropTypes.string,
     erasable: PropTypes.bool,
     error: PropTypes.bool,
     multiSelect: PropTypes.bool,

--- a/src/components/map/map-control.js
+++ b/src/components/map/map-control.js
@@ -97,7 +97,7 @@ const StyledMapControlPanel = styled.div`
 const StyledMapControlPanelContent = styled.div`
   ${props => props.theme.dropdownScrollBar} max-height: 500px;
   min-height: 100px;
-  overflow: auto;
+  overflow: scroll;
 `;
 
 const StyledMapControlPanelHeader = styled.div`
@@ -195,6 +195,74 @@ export class MapControl extends Component {
     layerSelector
   );
 
+<<<<<<< HEAD
+=======
+  // if one panel is already open and user tries to open a new one well the previous one will be closed
+  _toggleMenuPanel(panelId) {
+    this.setState({
+      areLayersVisible: false,
+      isLegendVisible: false,
+      [panelId]: !this.state[panelId]
+    });
+  }
+
+  _renderLayerSelector(items) {
+    const {onMapToggleLayer} = this.props;
+    const {areLayersVisible} = this.state;
+
+    return !areLayersVisible ? (
+      <StyledMapControlButton
+        key={1}
+        onClick={e => {
+          e.preventDefault();
+          this._toggleMenuPanel('areLayersVisible');
+        }}
+        className="map-control-button toggle-layer"
+        data-tip
+        data-for="toggle-layer"
+      >
+        <Layers height="22px" />
+        <MapLegendTooltip
+          id="toggle-layer"
+          message={areLayersVisible ? 'Hide layer panel' : 'Show layer panel'}
+        />
+      </StyledMapControlButton>
+    ) : (
+      <MapControlPanel
+        header={'Visible layers'}
+        onClick={() => this._toggleMenuPanel('areLayersVisible')}>
+        <MapLayerSelector layers={items} onMapToggleLayer={onMapToggleLayer} />
+      </MapControlPanel>
+    );
+  }
+
+  _renderLegend(items) {
+    const {isLegendVisible} = this.state;
+    return !isLegendVisible ? (
+      <StyledMapControlButton
+        key={2}
+        data-tip
+        data-for="show-legend"
+        className="map-control-button show-legend"
+        onClick={e => {
+          e.preventDefault();
+          this._toggleMenuPanel('isLegendVisible');
+        }}>
+        <Legend height="22px" />
+        <MapLegendTooltip id="show-legend" message={'show legend'} />
+      </StyledMapControlButton>
+    ) : (
+      <MapControlPanel
+        header={'Layer Legend'}
+        onClick={() => this._toggleMenuPanel('isLegendVisible')}>
+        <MapLegend
+          layers={items.filter(item => item.isVisible).map(item => item.layer)}
+        />
+      </MapControlPanel>
+    );
+  }
+
+>>>>>>> fix render map legend
   render() {
     const items = this.initialDataSelector(this.props);
 

--- a/src/components/map/map-control.js
+++ b/src/components/map/map-control.js
@@ -97,7 +97,7 @@ const StyledMapControlPanel = styled.div`
 const StyledMapControlPanelContent = styled.div`
   ${props => props.theme.dropdownScrollBar} max-height: 500px;
   min-height: 100px;
-  overflow: scroll;
+  overflow: auto;
 `;
 
 const StyledMapControlPanelHeader = styled.div`
@@ -195,74 +195,6 @@ export class MapControl extends Component {
     layerSelector
   );
 
-<<<<<<< HEAD
-=======
-  // if one panel is already open and user tries to open a new one well the previous one will be closed
-  _toggleMenuPanel(panelId) {
-    this.setState({
-      areLayersVisible: false,
-      isLegendVisible: false,
-      [panelId]: !this.state[panelId]
-    });
-  }
-
-  _renderLayerSelector(items) {
-    const {onMapToggleLayer} = this.props;
-    const {areLayersVisible} = this.state;
-
-    return !areLayersVisible ? (
-      <StyledMapControlButton
-        key={1}
-        onClick={e => {
-          e.preventDefault();
-          this._toggleMenuPanel('areLayersVisible');
-        }}
-        className="map-control-button toggle-layer"
-        data-tip
-        data-for="toggle-layer"
-      >
-        <Layers height="22px" />
-        <MapLegendTooltip
-          id="toggle-layer"
-          message={areLayersVisible ? 'Hide layer panel' : 'Show layer panel'}
-        />
-      </StyledMapControlButton>
-    ) : (
-      <MapControlPanel
-        header={'Visible layers'}
-        onClick={() => this._toggleMenuPanel('areLayersVisible')}>
-        <MapLayerSelector layers={items} onMapToggleLayer={onMapToggleLayer} />
-      </MapControlPanel>
-    );
-  }
-
-  _renderLegend(items) {
-    const {isLegendVisible} = this.state;
-    return !isLegendVisible ? (
-      <StyledMapControlButton
-        key={2}
-        data-tip
-        data-for="show-legend"
-        className="map-control-button show-legend"
-        onClick={e => {
-          e.preventDefault();
-          this._toggleMenuPanel('isLegendVisible');
-        }}>
-        <Legend height="22px" />
-        <MapLegendTooltip id="show-legend" message={'show legend'} />
-      </StyledMapControlButton>
-    ) : (
-      <MapControlPanel
-        header={'Layer Legend'}
-        onClick={() => this._toggleMenuPanel('isLegendVisible')}>
-        <MapLegend
-          layers={items.filter(item => item.isVisible).map(item => item.layer)}
-        />
-      </MapControlPanel>
-    );
-  }
-
->>>>>>> fix render map legend
   render() {
     const items = this.initialDataSelector(this.props);
 

--- a/src/components/map/map-popover.js
+++ b/src/components/map/map-popover.js
@@ -269,21 +269,20 @@ const EntryInfoRow = ({name, fields, data}) => {
 
 const CellInfo = ({data, layer}) => {
   const {colorField, sizeField} = layer.config;
-  const {colorAggregation, sizeAggregation} = layer.config.visConfig;
 
   return (
     <tbody>
       <Row name={'total points'} key="count" value={data.points.length} />
       {colorField ? (
         <Row
-          name={`${colorAggregation} ${colorField.name}`}
+          name={layer.getVisualChannelDescription('color').measure}
           key="color"
           value={data.colorValue || 'N/A'}
         />
       ) : null}
       {sizeField ? (
         <Row
-          name={`${sizeAggregation} ${sizeField.name}`}
+          name={layer.getVisualChannelDescription('size').measure}
           key="size"
           value={data.elevationValue || 'N/A'}
         />

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -191,12 +191,12 @@ export default class LayerConfigurator extends Component {
             {...visConfiguratorProps}
           />
         </LayerConfigGroup>
+
         {/* Aggregation Type */}
         <LayerConfigGroup label={'aggregation'}>
           <AggregationTypeSelector
             {...LAYER_VIS_CONFIGS.aggregation}
             {...layerChannelConfigProps}
-            property={'colorAggregation'}
             channel={layer.visualChannels.color}
           />
         </LayerConfigGroup>
@@ -745,14 +745,18 @@ export const ChannelByValueSelector = ({
   );
 };
 
-export const AggrColorScaleSelector = ({layer, onChange}) => (
-  <DimensionScaleSelector
-    label="Color Scale"
-    options={layer.getScaleOptions('color')}
-    scaleType={layer.config.colorScale}
-    onSelect={val => onChange({colorScale: val}, 'color')}
-  />
-);
+export const AggrColorScaleSelector = ({layer, onChange}) => {
+  const scaleOptions = layer.getScaleOptions('color');
+  return (
+    Array.isArray(scaleOptions) && scaleOptions.length > 1 ?
+      <DimensionScaleSelector
+        label="Color Scale"
+        options={scaleOptions}
+        scaleType={layer.config.colorScale}
+        onSelect={val => onChange({colorScale: val}, 'color')}
+      /> : null
+  );
+};
 
 export const AggregationTypeSelector = ({layer, channel, onChange}) => {
   const {field, aggregation, key} = channel;

--- a/src/components/side-panel/layer-panel/layer-type-selector.js
+++ b/src/components/side-panel/layer-panel/layer-type-selector.js
@@ -32,11 +32,6 @@ import {
   SidePanelSection
 } from 'components/common/styled-components';
 
-const ITEM_SIZE = {
-  large: 60,
-  small: 28
-};
-
 const StyledDropdownListItem = styled.div`
   padding-bottom: 12px;
   padding-right: 12px;
@@ -67,7 +62,7 @@ const StyledListItem = styled.div`
 
     .layer-type-selector__item__icon {
       color: ${props => props.theme.activeColor};
-      background-size: ${ITEM_SIZE.small}px ${ITEM_SIZE.small}px;
+      background-size: 28px 28px;
       margin-right: 12px;  
     }
   }
@@ -76,7 +71,7 @@ const StyledListItem = styled.div`
     color: ${props => props.theme.labelColor};
     display: flex;
     background-image: url(${`${CLOUDFRONT}/kepler.gl-layer-icon-bg.png`});
-    background-size: ${ITEM_SIZE.large}px ${ITEM_SIZE.large}px;
+    background-size: 64px 64px;
   }
 
   .layer-type-selector__item__label {
@@ -103,7 +98,7 @@ const LayerTypeListItem = ({value, isTile}) => (
   >
     <div className="layer-type-selector__item__icon">
       <value.icon
-        height={`${isTile ? ITEM_SIZE.large : ITEM_SIZE.small}px`}
+        height={isTile ? '64px' : '28px'}
       />
     </div>
     <div className="layer-type-selector__item__label">{value.label}</div>

--- a/src/components/side-panel/layer-panel/layer-type-selector.js
+++ b/src/components/side-panel/layer-panel/layer-type-selector.js
@@ -32,6 +32,11 @@ import {
   SidePanelSection
 } from 'components/common/styled-components';
 
+const ITEM_SIZE = {
+  large: 60,
+  small: 28
+};
+
 const StyledDropdownListItem = styled.div`
   padding-bottom: 12px;
   padding-right: 12px;
@@ -62,7 +67,7 @@ const StyledListItem = styled.div`
 
     .layer-type-selector__item__icon {
       color: ${props => props.theme.activeColor};
-      background-size: 28px 28px;
+      background-size: ${ITEM_SIZE.small}px ${ITEM_SIZE.small}px;
       margin-right: 12px;  
     }
   }
@@ -71,7 +76,7 @@ const StyledListItem = styled.div`
     color: ${props => props.theme.labelColor};
     display: flex;
     background-image: url(${`${CLOUDFRONT}/kepler.gl-layer-icon-bg.png`});
-    background-size: 64px 64px;
+    background-size: ${ITEM_SIZE.large}px ${ITEM_SIZE.large}px;
   }
 
   .layer-type-selector__item__label {
@@ -98,7 +103,7 @@ const LayerTypeListItem = ({value, isTile}) => (
   >
     <div className="layer-type-selector__item__icon">
       <value.icon
-        height={isTile ? '64px' : '28px'}
+        height={`${isTile ? ITEM_SIZE.large : ITEM_SIZE.small}px`}
       />
     </div>
     <div className="layer-type-selector__item__label">{value.label}</div>

--- a/src/components/side-panel/layer-panel/vis-config-by-field-selector.js
+++ b/src/components/side-panel/layer-panel/vis-config-by-field-selector.js
@@ -46,7 +46,8 @@ export default class VisConfigByFieldSelector extends Component {
     // optional
     selectedField: PropTypes.object,
     description: PropTypes.string,
-    label: PropTypes.string
+    label: PropTypes.string,
+    placeholder: PropTypes.string
   };
 
   _updateVisByField = val => {
@@ -79,6 +80,7 @@ export default class VisConfigByFieldSelector extends Component {
           <FieldSelector
             fields={this.props.fields}
             value={selectedField && selectedField.name}
+            placeholder={this.props.placeholder}
             onSelect={this._updateVisByField}
             erasable
           />

--- a/src/components/side-panel/layer-panel/vis-config-by-field-selector.js
+++ b/src/components/side-panel/layer-panel/vis-config-by-field-selector.js
@@ -34,16 +34,15 @@ import {capitalizeFirstLetter} from 'utils/utils';
 export default class VisConfigByFieldSelector extends Component {
   static propTypes = {
     channel: PropTypes.string.isRequired,
-    domain: PropTypes.arrayOf(PropTypes.any).isRequired,
     fields: PropTypes.arrayOf(PropTypes.any).isRequired,
     id: PropTypes.string.isRequired,
     property: PropTypes.string.isRequired,
-    scaleType: PropTypes.string.isRequired,
     showScale: PropTypes.bool.isRequired,
     updateField: PropTypes.func.isRequired,
     updateScale: PropTypes.func.isRequired,
 
     // optional
+    scaleType: PropTypes.string,
     selectedField: PropTypes.object,
     description: PropTypes.string,
     label: PropTypes.string,

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -346,10 +346,10 @@ export const  notSupportAggrOpts = {
  */
 export const DEFAULT_AGGREGATION = {
   [CHANNEL_SCALES.colorAggr]: {
-    [AGGREGATION_TYPES.count]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
+    [AGGREGATION_TYPES.count]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile]
   },
   [CHANNEL_SCALES.sizeAggr]: {
-    [AGGREGATION_TYPES.count]: [SCALE_TYPES.linear],
+    [AGGREGATION_TYPES.count]: [SCALE_TYPES.linear]
   }
 };
 

--- a/src/deckgl-layers/layer-utils/utils.js
+++ b/src/deckgl-layers/layer-utils/utils.js
@@ -18,7 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {scaleQuantize, scaleQuantile, scaleSqrt} from 'd3-scale';
+import {scaleQuantize, scaleOrdinal, scaleQuantile, scaleSqrt} from 'd3-scale';
+import {unique} from 'utils//data-utils';
+
 import {SCALE_TYPES} from 'constants/default-settings';
 
 // Enable render color by customized color Scale
@@ -29,7 +31,8 @@ export function getBinColorDomain(scaleType, bins, [lowerIdx, upperIdx]) {
 
     case SCALE_TYPES.quantile:
       return bins.slice(lowerIdx, upperIdx + 1).map(d => d.value);
-
+    case SCALE_TYPES.ordinal:
+      return unique(bins.map(b => b.value)).sort();
     default:
       return [bins[lowerIdx].value, bins[upperIdx].value];
   }
@@ -42,7 +45,8 @@ export function getScaleFunctor(scaleType) {
 
     case SCALE_TYPES.quantile:
       return scaleQuantile;
-
+    case SCALE_TYPES.ordinal:
+      return scaleOrdinal;
     default:
       return scaleQuantile;
   }

--- a/src/layers/aggregation-layer.js
+++ b/src/layers/aggregation-layer.js
@@ -83,27 +83,27 @@ export default class AggregationLayer extends Layer {
   get visualChannels() {
     return {
       color: {
-        property: 'color',
-        field: 'colorField',
-        scale: 'colorScale',
-        domain: 'colorDomain',
-        range: 'colorRange',
         aggregation: 'colorAggregation',
-        key: 'color',
         channelScaleType: CHANNEL_SCALES.colorAggr,
-        defaultMeasure: 'Point Count'
+        defaultMeasure: 'Point Count',
+        domain: 'colorDomain',
+        field: 'colorField',
+        key: 'color',
+        property: 'color',
+        range: 'colorRange',
+        scale: 'colorScale'
       },
       size: {
-        property: 'height',
-        field: 'sizeField',
-        scale: 'sizeScale',
-        domain: 'sizeDomain',
-        range: 'sizeRange',
         aggregation: 'sizeAggregation',
-        key: 'size',
         channelScaleType: CHANNEL_SCALES.sizeAggr,
+        condition: config => config.visConfig.enable3d,
         defaultMeasure: 'Point Count',
-        condition: config => config.visConfig.enable3d
+        domain: 'sizeDomain',
+        field: 'sizeField',
+        key: 'size',
+        property: 'height',
+        range: 'sizeRange',
+        scale: 'sizeScale'
       }
     };
   }
@@ -155,6 +155,10 @@ export default class AggregationLayer extends Layer {
     const visualChannel = this.visualChannels[channel];
     const {field, aggregation} = visualChannel;
     const aggregationOptions = this.getAggregationOptions(channel);
+
+    if (!aggregation) {
+      return;
+    }
 
     if (!aggregationOptions.length) {
       // if field cannot be aggregated, set field to null

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -414,7 +414,6 @@ export default class Layer {
     const copied = this.copyLayerConfig(currentConfig, configToCopy, {notToDeepMerge, notToCopy});
 
     this.updateLayerConfig(copied);
-
     // validate visualChannel field type and scale types
     Object.keys(this.visualChannels).forEach(channel => {
       this.validateVisualChannel(channel);
@@ -657,13 +656,13 @@ export default class Layer {
    */
   validateFieldType(channel) {
     const visualChannel = this.visualChannels[channel];
-    const {field, channelScaleType} = visualChannel;
+    const {field, channelScaleType, supportedFieldTypes} = visualChannel;
 
     if (this.config[field]) {
       // if field is selected, check if field type is supported
-      const supportedFieldType = CHANNEL_SCALE_SUPPORTED_FIELDS[channelScaleType];
+      const channelSupportedFieldTypes = supportedFieldTypes || CHANNEL_SCALE_SUPPORTED_FIELDS[channelScaleType];
 
-      if (!supportedFieldType.includes(this.config[field].type)) {
+      if (!channelSupportedFieldTypes.includes(this.config[field].type)) {
         // field type is not supported, set it back to null
         // set scale back to default
         this.updateLayerConfig({[field]: null});
@@ -677,7 +676,10 @@ export default class Layer {
   validateScale(channel) {
     const visualChannel = this.visualChannels[channel];
     const {scale} = visualChannel;
-
+    if (!scale) {
+      // visualChannel doesn't have scale
+      return;
+    }
     const scaleOptions = this.getScaleOptions(channel);
     // check if current selected scale is
     // supported, if not, change to default

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -271,7 +271,7 @@ export default class Layer {
       isConfigActive: props.isConfigActive || false,
       highlightColor: props.highlightColor || [252, 242, 26],
 
-      // TODO: refactor this into seperate visual Channel config
+      // TODO: refactor this into separate visual Channel config
       // color by field, domain is set by filters, field, scale type
       colorField: null,
       colorDomain: [0, 1],

--- a/src/layers/cluster-layer/cluster-layer.js
+++ b/src/layers/cluster-layer/cluster-layer.js
@@ -30,14 +30,12 @@ export const clusterVisConfigs = {
   colorRange: 'colorRange',
   radiusRange: 'clusterRadiusRange',
   'hi-precision': 'hi-precision',
-  colorAggregation: 'aggregation',
-  sizeAggregation: 'aggregation'
+  colorAggregation: 'aggregation'
 };
 
 export default class ClusterLayer extends AggregationLayer {
   constructor(props) {
     super(props);
-
     this.registerVisConfig(clusterVisConfigs);
   }
 
@@ -51,14 +49,15 @@ export default class ClusterLayer extends AggregationLayer {
   get visualChannels() {
     return {
       color: {
-        property: 'color',
-        field: 'colorField',
-        scale: 'colorScale',
-        domain: 'colorDomain',
-        range: 'colorRange',
-        key: 'color',
+        aggregation: 'colorAggregation',
+        channelScaleType: CHANNEL_SCALES.colorAggr,
         defaultMeasure: 'Point Count',
-        channelScaleType: CHANNEL_SCALES.colorAggr
+        domain: 'colorDomain',
+        field: 'colorField',
+        key: 'color',
+        property: 'color',
+        range: 'colorRange',
+        scale: 'colorScale'
       }
     };
   }

--- a/src/layers/grid-layer/grid-layer.js
+++ b/src/layers/grid-layer/grid-layer.js
@@ -31,11 +31,11 @@ export const gridVisConfigs = {
   coverage: 'coverage',
   sizeRange: 'elevationRange',
   percentile: 'percentile',
-  elevationPercentile: 'percentile',
+  elevationPercentile: 'elevationPercentile',
   elevationScale: 'elevationScale',
   'hi-precision': 'hi-precision',
   colorAggregation: 'aggregation',
-  sizeAggregation: 'aggregation',
+  sizeAggregation: 'sizeAggregation',
   enable3d: 'enable3d'
 };
 

--- a/src/layers/grid-layer/grid-layer.js
+++ b/src/layers/grid-layer/grid-layer.js
@@ -44,6 +44,7 @@ export default class GridLayer extends AggregationLayer {
     super(props);
 
     this.registerVisConfig(gridVisConfigs);
+    this.visConfigSettings.worldUnitSize.label = 'Grid Size (km)';
   }
 
   get type() {

--- a/src/layers/hexagon-layer/hexagon-layer.js
+++ b/src/layers/hexagon-layer/hexagon-layer.js
@@ -36,7 +36,7 @@ export const hexagonVisConfigs = {
   elevationScale: 'elevationScale',
   'hi-precision': 'hi-precision',
   colorAggregation: 'aggregation',
-  sizeAggregation: 'aggregation',
+  sizeAggregation: 'sizeAggregation',
   enable3d: 'enable3d'
 };
 

--- a/src/layers/hexagon-layer/hexagon-layer.js
+++ b/src/layers/hexagon-layer/hexagon-layer.js
@@ -45,6 +45,7 @@ export default class HexagonLayer extends AggregationLayer {
     super(props);
 
     this.registerVisConfig(hexagonVisConfigs);
+    this.visConfigSettings.worldUnitSize.label = 'Hexagon Radius (km)';
   }
 
   get type() {

--- a/src/layers/layer-factory.js
+++ b/src/layers/layer-factory.js
@@ -20,7 +20,7 @@
 
 import keyMirror from 'keymirror';
 
-import {AGGREGATION_TYPES, FIELD_OPTS, LinearFieldAggrTypes} from 'constants/default-settings';
+import {AGGREGATION_TYPES} from 'constants/default-settings';
 import {DefaultColorRange} from 'constants/color-ranges';
 
 export const PROPERTY_GROUPS = keyMirror({
@@ -226,7 +226,7 @@ export const LAYER_VIS_CONFIGS = {
     label: 'Elevation Scale',
     isRanged: false,
     range: [0, 100],
-    step: 1,
+    step: 0.1,
     group: PROPERTY_GROUPS.height,
     property: 'elevationScale'
   },
@@ -288,12 +288,13 @@ export const LAYER_VIS_CONFIGS = {
   weight: {
     type: 'number',
     defaultValue: 1,
-    label: 'Weight',
+    label: 'Weight Intensity',
     isRanged: false,
     range: [0.01, 500],
     step: 0.01,
     group: PROPERTY_GROUPS.cell,
-    property: 'weight'
+    property: 'weight',
+    condition: config => config.weightField
   },
   heatmapRadius: {
     type: 'number',

--- a/src/layers/layer-factory.js
+++ b/src/layers/layer-factory.js
@@ -20,7 +20,7 @@
 
 import keyMirror from 'keymirror';
 
-import {AGGREGATION_TYPES} from 'constants/default-settings';
+import {AGGREGATION_TYPES, FIELD_OPTS, LinearFieldAggrTypes} from 'constants/default-settings';
 import {DefaultColorRange} from 'constants/color-ranges';
 
 export const PROPERTY_GROUPS = keyMirror({
@@ -149,9 +149,21 @@ export const LAYER_VIS_CONFIGS = {
     type: 'select',
     defaultValue: AGGREGATION_TYPES.average,
     label: 'Color Aggregation',
+    // aggregation options are based on color field types
     options: Object.keys(AGGREGATION_TYPES),
     group: PROPERTY_GROUPS.color,
-    property: 'colorAggregation'
+    property: 'colorAggregation',
+    condition: config => config.colorField
+  },
+  sizeAggregation: {
+    type: 'select',
+    defaultValue: AGGREGATION_TYPES.average,
+    label: 'Height Aggregation',
+    // aggregation options are based on color field types
+    options: Object.keys(AGGREGATION_TYPES),
+    group: PROPERTY_GROUPS.height,
+    property: 'sizeAggregation',
+    condition: config => config.sizeField
   },
   percentile: {
     type: 'number',
@@ -166,7 +178,10 @@ export const LAYER_VIS_CONFIGS = {
     range: [0, 100],
     step: 0.01,
     group: PROPERTY_GROUPS.color,
-    property: 'percentile'
+    property: 'percentile',
+
+    // percentile filter only makes sense with linear aggregation
+    condition: config => config.colorScale !== 'ordinal'
   },
   elevationPercentile: {
     type: 'number',
@@ -181,7 +196,9 @@ export const LAYER_VIS_CONFIGS = {
     range: [0, 100],
     step: 0.01,
     group: PROPERTY_GROUPS.height,
-    property: 'elevationPercentile'
+    property: 'elevationPercentile',
+    // percentile filter only makes sense with linear aggregation
+    condition: config => config.visConfig.enable3d && (config.colorField || config.sizeField)
   },
   resolution: {
     type: 'number',

--- a/src/layers/mapbox-utils.js
+++ b/src/layers/mapbox-utils.js
@@ -61,6 +61,7 @@ export function generateMapboxLayers(layers = [], layerData = [], layerOrder = [
  */
 export function updateMapboxLayers(map, newLayers = [], oldLayers = null, mapLayers = null, opt = {force: true}) {
   // delete non existing layers
+
   if (oldLayers) {
     const oldLayersKeys = Object.keys(oldLayers);
     if (newLayers.length === 0 && oldLayersKeys.length > 0) {

--- a/src/layers/mapboxgl-layer.js
+++ b/src/layers/mapboxgl-layer.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {CHANNEL_SCALES} from 'constants/default-settings';
 import Layer, {OVERLAY_TYPE} from './base-layer';
 
 export const mapboxRequiredColumns = ['lat', 'lng'];
@@ -50,28 +49,7 @@ class MapboxLayerGL extends Layer {
   }
 
   get visualChannels() {
-    return {
-      // color: {
-      //   property: 'color',
-      //   field: 'colorField',
-      //   scale: 'colorScale',
-      //   domain: 'colorDomain',
-      //   range: 'colorRange',
-      //   key: 'color',
-      //   channelScaleType: CHANNEL_SCALES.colorAggr,
-      //   defaultMeasure: 'Point Count'
-      // },
-      // weight: {
-      //   property: 'weight',
-      //   field: 'weightField',
-      //   scale: 'weightScale',
-      //   domain: 'weightDomain',
-      //   range: 'weightRange',
-      //   key: 'weight',
-      //   channelScaleType: CHANNEL_SCALES.sizeAggr,
-      //   defaultMeasure: 'Weight'
-      // }
-    };
+    return {};
   }
 
   // this layer is rendered at mapbox level

--- a/src/layers/mapboxgl-layer.js
+++ b/src/layers/mapboxgl-layer.js
@@ -51,26 +51,26 @@ class MapboxLayerGL extends Layer {
 
   get visualChannels() {
     return {
-      color: {
-        property: 'color',
-        field: 'colorField',
-        scale: 'colorScale',
-        domain: 'colorDomain',
-        range: 'colorRange',
-        key: 'color',
-        channelScaleType: CHANNEL_SCALES.colorAggr,
-        defaultMeasure: 'Point Count'
-      },
-      weight: {
-        property: 'weight',
-        field: 'weightField',
-        scale: 'weightScale',
-        domain: 'weightDomain',
-        range: 'weightRange',
-        key: 'weight',
-        channelScaleType: CHANNEL_SCALES.sizeAggr,
-        defaultMeasure: 'Weight'
-      }
+      // color: {
+      //   property: 'color',
+      //   field: 'colorField',
+      //   scale: 'colorScale',
+      //   domain: 'colorDomain',
+      //   range: 'colorRange',
+      //   key: 'color',
+      //   channelScaleType: CHANNEL_SCALES.colorAggr,
+      //   defaultMeasure: 'Point Count'
+      // },
+      // weight: {
+      //   property: 'weight',
+      //   field: 'weightField',
+      //   scale: 'weightScale',
+      //   domain: 'weightDomain',
+      //   range: 'weightRange',
+      //   key: 'weight',
+      //   channelScaleType: CHANNEL_SCALES.sizeAggr,
+      //   defaultMeasure: 'Weight'
+      // }
     };
   }
 

--- a/src/utils/aggregate-utils.js
+++ b/src/utils/aggregate-utils.js
@@ -21,6 +21,17 @@
 import {min, max, mean, median, sum} from 'd3-array';
 import {AGGREGATION_TYPES} from 'constants/default-settings';
 
+const getFrenquency = data => data.reduce((uniques, val) => {
+  uniques[val] = (uniques[val] || 0) + 1;
+  return uniques;
+}, {});
+
+function getMode(data) {
+  const occur = getFrenquency(data);
+  return Object.keys(occur).reduce((prev, key) =>
+    occur[prev] >= occur[key] ? prev : key, Object.keys(occur)[0]);
+}
+
 export function aggregate(data, technique) {
   switch (technique) {
     case AGGREGATION_TYPES.average:
@@ -28,10 +39,14 @@ export function aggregate(data, technique) {
     case AGGREGATION_TYPES.countUnique:
       return Object.keys(
         data.reduce((uniques, val) => {
-          uniques[val] = true;
+          uniques[val] = uniques[val] || 0;
+          uniques[val] += 1;
           return uniques;
         }, {})
       ).length;
+    case AGGREGATION_TYPES.mode:
+      return getMode(data);
+
     case AGGREGATION_TYPES.maximum:
       return max(data);
     case AGGREGATION_TYPES.minimum:

--- a/src/utils/data-scale-utils.js
+++ b/src/utils/data-scale-utils.js
@@ -45,7 +45,7 @@ export function getOrdinalDomain(data, valueAccessor) {
   const values =
     typeof valueAccessor === 'function' ? data.map(valueAccessor) : data;
 
-  return unique(values).filter(notNullorUndefined);
+  return unique(values).filter(notNullorUndefined).sort();
 }
 
 /**

--- a/test/fixtures/state-saved-v0.js
+++ b/test/fixtures/state-saved-v0.js
@@ -897,7 +897,7 @@ export const mergedFilters = [
     name: 'song_name',
     type: 'multiSelect',
     fieldIdx: 0,
-    domain: ['3.68.4', '2.117.1', '2.116.2', '2.103.2', '2.107.3'],
+    domain: ['2.103.2', '2.107.3', '2.116.2', '2.117.1', '3.68.4' ],
     value: ['3.68.4', '2.117.1', '2.103.2', '2.116.2'],
     fieldType: 'string',
     plotType: 'histogram',
@@ -1152,7 +1152,7 @@ mergedLayer2.config = {
     tableFieldIndex: 1
   },
   colorScale: 'ordinal',
-  colorDomain: ['3.68.4', '2.117.1', '2.116.2', '2.103.2', '2.107.3'],
+  colorDomain: ['2.103.2', '2.107.3', '2.116.2', '2.117.1', '3.68.4'],
   sizeField: {
     name: 'int_range',
     format: '',

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -287,8 +287,8 @@ export const expectedSavedLayer0 = {
       elevationPercentile: [0, 100],
       elevationScale: 5,
       'hi-precision': false,
-      colorAggregation: 'average',
-      sizeAggregation: 'average',
+      colorAggregation: 'count',
+      sizeAggregation: 'count',
       enable3d: false
     }
   },
@@ -335,8 +335,8 @@ export const expectedLoadedLayer0 = {
       elevationPercentile: [0, 100],
       elevationScale: 5,
       'hi-precision': false,
-      colorAggregation: 'average',
-      sizeAggregation: 'average',
+      colorAggregation: 'count',
+      sizeAggregation: 'count',
       enable3d: false
     },
     colorField: null,

--- a/test/node/layer-tests/heatmap-layer-specs.js
+++ b/test/node/layer-tests/heatmap-layer-specs.js
@@ -40,9 +40,9 @@ test('#HeatmapLayer -> contructor', t => {
         test: layer => {
           // test constructor
           t.equal(
-            layer.config.visConfig.weight,
-            1,
-            'Heatmap default layer weight should be 1'
+            layer.config.visConfig.radius,
+            20,
+            'Heatmap default radius should be 20'
           )
         }
       }

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -458,18 +458,18 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', t => {
   t.equal(newLayer3.type, 'hexagon', 'should change type to hexagon');
   t.equal(
     newLayer3.config.colorField,
-    null,
-    'should set colorField back to null'
+    stringField,
+    'should keep colorField'
   );
   t.deepEqual(
     newLayer3.config.colorDomain,
     [0, 1],
-    'should set colorDomain back to default'
+    'should set colorDomain to default, it is calculated inside deck.gl layer'
   );
   t.equal(
     newLayer3.config.colorScale,
-    'quantile',
-    'should set colorScale to default'
+    'ordinal',
+    'should set colorScale to ordinal'
   );
   t.equal(
     newLayer3.config.sizeScale,

--- a/test/node/utils/data-scale-utils-test.js
+++ b/test/node/utils/data-scale-utils-test.js
@@ -30,7 +30,6 @@ function numberSort(a, b) {
 }
 
 test('DataScaleUtils -> getOrdinalDomain', t => {
-  t.plan(2);
 
   const data = ['a', 'a', 'b', undefined, null, 0];
   function valueAccessor(d) {
@@ -39,15 +38,16 @@ test('DataScaleUtils -> getOrdinalDomain', t => {
 
   const values = [{value: 'a'}, {value: 'b'}, {value: 'b'}];
 
-  t.deepEqual(getOrdinalDomain(data), ['a', 'b', 0],
+  t.deepEqual(getOrdinalDomain(data), [0, 'a', 'b'],
     'should get correct ordinal domain');
 
   t.deepEqual(getOrdinalDomain(values, valueAccessor), ['a', 'b'],
     'should get correct ordinal domain');
+
+  t.end();
 });
 
 test('DataScaleUtils -> getQuantileDomain', t => {
-  t.plan(3);
 
   const data = ['a', 'b', 'c', 'b', undefined, null];
   const quanData = [1, 4, 2, 3, 1, undefined, null, 0];
@@ -65,10 +65,11 @@ test('DataScaleUtils -> getQuantileDomain', t => {
 
   t.deepEqual(getQuantileDomain(values, valueAccessor), ['a', 'b', 'b'],
     'should get correct quantile domain');
+
+  t.end();
 });
 
 test('DataScaleUtils -> getLinearDomain', t => {
-  t.plan(5);
 
   const quanData = [1, 4, 2, 3, 1, undefined, null, 0];
   function valueAccessor(d) {
@@ -91,4 +92,6 @@ test('DataScaleUtils -> getLinearDomain', t => {
 
   t.deepEqual(getLinearDomain(values, valueAccessor), [-3, 1],
     'should get correct Linear domain');
+
+  t.end();
 });


### PR DESCRIPTION
- Enable ordinal aggregation type `mode` and `count unique` in aggregation layer
- Added additional validation in visual channel updater to validate aggregation type and scale based on selected field
- Added more condition clause to layer visConfigSettings to render configuration selectively based on current layer config
- Specify aggregation type in layer legend and map popover 

**Hexbin aggregation by event type**
<img width="1253" alt="screen shot 2018-05-13 at 1 47 30 pm" src="https://user-images.githubusercontent.com/3605556/39971694-3f025092-56b4-11e8-9146-bcf73812e155.png">

**Legend**
<img width="290" alt="screen shot 2018-05-13 at 1 47 40 pm" src="https://user-images.githubusercontent.com/3605556/39971695-41b36cea-56b4-11e8-8550-afd272414b7d.png">
