### PR TITLE
Remove string refs from components in favor of callback-style

### DIFF
--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -101,11 +101,11 @@ const StyledFileUpload = styled.div`
     height: 0;
     position: absolute;
   }
-  
+
   .file-drop {
     position: relative;
   }
-  
+
   .file-upload__message {
     color: ${props => props.theme.textColorLT};
     font-size: 14px;
@@ -212,7 +212,6 @@ export default class FileUpload extends Component {
         <input
           className="filter-upload__input"
           type="file"
-          ref="fileInput"
           onChange={this._onChange}
         />
         {FileDrop ? (

--- a/src/components/common/file-uploader/upload-button.js
+++ b/src/components/common/file-uploader/upload-button.js
@@ -42,8 +42,8 @@ export default class UploadButton extends Component {
   };
 
   _onClick = () => {
-    this.refs.fileInput.value = null;
-    this.refs.fileInput.click();
+    this._fileInput.value = null;
+    this._fileInput.click();
   };
 
   _onChange = ({target: {files}}) => {
@@ -59,7 +59,7 @@ export default class UploadButton extends Component {
       <Wrapper>
         <input
           type="file"
-          ref="fileInput"
+          ref={ref => {this._fileInput = ref}}
           style={{display: 'none'}}
           onChange={this._onChange}
         />

--- a/src/components/common/item-selector/typeahead.js
+++ b/src/components/common/item-selector/typeahead.js
@@ -227,7 +227,6 @@ export default class Typeahead extends Component {
   _renderIncrementalSearchResults() {
     return (
       <this.props.customListComponent
-        ref="sel"
         fixedOptions={this.props.fixedOptions}
         options={
           this.props.maxVisible

--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -113,8 +113,8 @@ export default function MapContainerFactory(MapPopover, MapControl) {
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if (!this._map && this.refs.mapbox) {
-        this._map = this.refs.mapbox.getMap();
+      if (!this._map && this._mapbox) {
+        this._map = this._mapbox.getMap();
         // bind mapboxgl event listener
         this._map.on(MAPBOXGL_STYLE_UPDATE, () => {
           // force refresh mapboxgl layers
@@ -453,7 +453,7 @@ export default function MapContainerFactory(MapPopover, MapControl) {
           <this.props.MapComponent
             {...mapProps}
             key="bottom"
-            ref="mapbox"
+            ref={ref => {this._mapbox = ref}}
             mapStyle={mapStyle.bottomMapStyle}
             onClick={onMapClick}
           >

--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -112,34 +112,6 @@ export default function MapContainerFactory(MapPopover, MapControl) {
       }
     }
 
-    componentDidUpdate(prevProps, prevState) {
-      if (!this._map && this._mapbox) {
-        this._map = this._mapbox.getMap();
-        // bind mapboxgl event listener
-        this._map.on(MAPBOXGL_STYLE_UPDATE, () => {
-          // force refresh mapboxgl layers
-
-          updateMapboxLayers(
-            this._map,
-            this._renderMapboxLayers(),
-            this.previousLayers,
-            this.props.mapLayers,
-            {force: true}
-          );
-
-          if (typeof this.props.onMapStyleLoaded === 'function') {
-            this.props.onMapStyleLoaded(this._map);
-          }
-        });
-
-        this._map.on('render', () => {
-          if (typeof this.props.onMapRender === 'function') {
-            this.props.onMapRender(this._map);
-          }
-        });
-      }
-    }
-
     componentWillUnmount() {
       // unbind mapboxgl event listener
       if (this._map) {
@@ -190,6 +162,34 @@ export default function MapContainerFactory(MapPopover, MapControl) {
       const {index: mapIndex = 0, visStateActions} = this.props;
       visStateActions.toggleLayerForMap(mapIndex, layerId);
     };
+
+    _setMapboxMap = (mapbox) => {
+      if (!this._map && mapbox) {
+        this._map = mapbox.getMap();
+        // bind mapboxgl event listener
+        this._map.on(MAPBOXGL_STYLE_UPDATE, () => {
+          // force refresh mapboxgl layers
+
+          updateMapboxLayers(
+            this._map,
+            this._renderMapboxLayers(),
+            this.previousLayers,
+            this.props.mapLayers,
+            {force: true}
+          );
+
+          if (typeof this.props.onMapStyleLoaded === 'function') {
+            this.props.onMapStyleLoaded(this._map);
+          }
+        });
+
+        this._map.on('render', () => {
+          if (typeof this.props.onMapRender === 'function') {
+            this.props.onMapRender(this._map);
+          }
+        });
+      }
+    }
 
     /* deck.gl doesn't support blendFuncSeparate yet
      * so we're applying the blending ourselves
@@ -453,7 +453,7 @@ export default function MapContainerFactory(MapPopover, MapControl) {
           <this.props.MapComponent
             {...mapProps}
             key="bottom"
-            ref={ref => {this._mapbox = ref}}
+            ref={this._setMapboxMap}
             mapStyle={mapStyle.bottomMapStyle}
             onClick={onMapClick}
           >

--- a/src/components/modals/data-table-modal.js
+++ b/src/components/modals/data-table-modal.js
@@ -95,7 +95,7 @@ export class DataTableModal extends Component {
     // positions of a container.
 
     // react-data-grid canvas element can be scrolled
-    const canvas = this.refs.root.querySelector('.react-grid-Canvas');
+    const canvas = this._root.querySelector('.react-grid-Canvas');
 
     // If canvas can not be scrolled left anymore when we try to scroll left
     const prevent_left = e.deltaX < 0 && canvas.scrollLeft <= 0;
@@ -128,7 +128,7 @@ export class DataTableModal extends Component {
       .filter(({name}) => name !== '_geojson');
 
     return (
-      <div ref="root" className="dataset-modal" style={{overflow: 'scroll'}}>
+      <div ref={ref => {this._root = ref}} className="dataset-modal" style={{overflow: 'scroll'}}>
         <DatasetTabs
           activeDataset={activeDataset}
           datasets={datasets}


### PR DESCRIPTION
String refs are causing an issue on Observable (see below) and have been [deprecated](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs) in React for a few years now.

<img width="1173" alt="screenshot 2018-05-29 22 47 56" src="https://user-images.githubusercontent.com/931368/40696107-59ae3fec-6392-11e8-89fa-f3292761dc68.png">

The new hotness is [React.createRef](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) but I feel like we can codemod that at some point in the future if needed.