### PR TITLE
bugfix: TimeRangeSlider should not cache props.onChange

### DIFF
--- a/src/components/common/time-range-slider.js
+++ b/src/components/common/time-range-slider.js
@@ -65,7 +65,6 @@ export default class TimeRangeSlider extends Component {
       width: 288
     };
     this._animation = null;
-    this._sliderThrottle = throttle(this.props.onChange, 20);
   }
 
   componentDidUpdate() {
@@ -119,9 +118,9 @@ export default class TimeRangeSlider extends Component {
   };
 
   render() {
-    const {domain, value, isEnlarged} = this.props;
+    const {domain, value, isEnlarged, onChange} = this.props;
     const {isAnimating} = this.state;
-
+    this._sliderThrottle = throttle(onChange, 20);
     return (
       <div className="time-range-slider">
         <TimeTitle

--- a/src/components/common/time-range-slider.js
+++ b/src/components/common/time-range-slider.js
@@ -65,6 +65,7 @@ export default class TimeRangeSlider extends Component {
       width: 288
     };
     this._animation = null;
+    this._sliderThrottle = throttle((value) => this.props.onChange(value), 20);
   }
 
   componentDidUpdate() {
@@ -118,9 +119,9 @@ export default class TimeRangeSlider extends Component {
   };
 
   render() {
-    const {domain, value, isEnlarged, onChange} = this.props;
+    const {domain, value, isEnlarged} = this.props;
     const {isAnimating} = this.state;
-    this._sliderThrottle = throttle(onChange, 20);
+
     return (
       <div className="time-range-slider">
         <TimeTitle

--- a/src/components/common/time-range-slider.js
+++ b/src/components/common/time-range-slider.js
@@ -65,7 +65,7 @@ export default class TimeRangeSlider extends Component {
       width: 288
     };
     this._animation = null;
-    this._sliderThrottle = throttle((value) => this.props.onChange(value), 20);
+    this._sliderThrottle = throttle((...value) => this.props.onChange(...value), 20);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
onChange should be updated in render() function to make TimeRangeSlider reusable
fix #99