### PR TITLE
Bugfix: Create ellipsis when dataset name is a long name

### DIFF
--- a/src/components/side-panel/source-data-catalog.js
+++ b/src/components/side-panel/source-data-catalog.js
@@ -36,7 +36,7 @@ const DatasetTitle = styled.div`
   color: ${props => props.theme.textColor};
   display: flex;
   align-items: flex-start;
-  
+
   .source-data-arrow {
     height: 16px;
   }
@@ -60,9 +60,16 @@ const DatasetTagWrapper = styled.div`
   color: ${props => props.theme.textColor};
   font-size: 11px;
   letter-spacing: 0.2px;
-  
+
   .dataset-color {
     margin-top: 5px;
+  }
+
+  .dataset-name {
+    width: 11rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `;
 


### PR DESCRIPTION
The problem is documented in #84. Essentially, if you have a dataset without a space in the name, it will stretch the `.dataset-name` container really wide - making it impossible to see the delete or view the dataset you uploaded.

The solution I took was to add a `width`, `overflow`, and `text-overflow` to the `.dataset-name` class. This will also keep all dataset names on 1 line. When data sets had spaces and were very long, it would put the dataset name on multiple lines. I feel that this is a consistent approach to solving this issue.

Photo of proposed solution - 
<img width="353" alt="screen shot 2018-06-06 at 6 34 05 pm" src="https://user-images.githubusercontent.com/1751160/41072025-776513c2-69b8-11e8-8299-3f90bdadc03c.png">

Looking forward to utilizing and contributing to kepler with a bigger PR in the future. Let me know if there are any issues with this proposed solution. 