### PR TITLE
Change CONFIG_UPLOAD_MESSAGE to avoid confusion

### DIFF
--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -50,7 +50,7 @@ const CHROME_MSG =
   '*Chrome user: Limit file size to 250mb, if need to upload larger file, try Safari';
 const DISCLAIMER = '*Kepler.gl is a client-side application with no server backend. Data lives only on your machine/browser. ' +
   'No information or map data is sent to any server.';
-const CONFIG_UPLOAD_MESSAGE = 'Upload data files or upload saved maps from Json containing config and data';
+const CONFIG_UPLOAD_MESSAGE = 'Upload data files or upload a saved map via previously exported single Json of both config and data';
 
 const fileIconColor = '#D3D8E0';
 


### PR DESCRIPTION
Very small change to wording of the CONFIG_UPLOAD_MESSAGE to make it clear that, to upload a previous map, you have to upload a **single** JSON that contains **both** the old data and all config. 

Trying to upload separate JSONs, _which seems like a possible way forward with the old message_, in fact doesn't work and results in a map that tries to load forever. 