### PR TITLE
[website] fix video autoplay issue in Chrome

### DIFF
--- a/website/src/components/walkthrough.js
+++ b/website/src/components/walkthrough.js
@@ -118,6 +118,7 @@ class Walkthrough extends PureComponent {
               <VideoWrapper key={videoUrl}>
                 <VideoContainer>
                   <video
+                    muted
                     src={videoUrl}
                     poster={imageUrl}
                     autoPlay={i === selectedIndex}


### PR DESCRIPTION
It looks like Chrome occasionally blocks autoplaying the walkthrough videos because of this newish policy (prevents playing unmuted videos): https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

