### PR TITLE
[Enhancement] Add default map styles to mapStyle reducer initial state

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,10 +22,12 @@
 export {default as KeplerGl, default, injectComponents} from './container';
 
 // factories
+export {default as KeplerGlFactory} from './kepler-gl';
 export {default as SidePanelFactory} from './side-panel';
 export {default as MapContainerFactory} from './map-container';
 export {default as BottomWidgetFactory} from './bottom-widget';
 export {default as ModalContainerFactory} from './modal-container';
+export {default as PlotContainerFactory} from './plot-container';
 
 // // side panel factories
 export {default as PanelHeaderFactory} from './side-panel/panel-header'
@@ -60,4 +62,3 @@ export {default as Switch} from './common/switch';
 export {default as LoadingSpinner} from './common/loading-spinner';
 export * from './common/styled-components';
 export * as Icons from './common/icons';
-

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -30,7 +30,7 @@ import * as MapStateActions from 'actions/map-state-actions';
 import * as MapStyleActions from 'actions/map-style-actions';
 import * as UIStateActions from 'actions/ui-state-actions';
 
-import {EXPORT_IMAGE_ID, DIMENSIONS, DEFAULT_MAP_STYLES,
+import {EXPORT_IMAGE_ID, DIMENSIONS,
   KEPLER_GL_NAME, KEPLER_GL_VERSION} from 'constants/default-settings';
 
 import SidePanelFactory from './side-panel';
@@ -38,6 +38,8 @@ import MapContainerFactory from './map-container';
 import BottomWidgetFactory from './bottom-widget';
 import ModalContainerFactory from './modal-container';
 import PlotContainerFactory from './plot-container';
+
+import {generateHashId} from 'utils/utils';
 
 import {theme} from 'styles/base';
 
@@ -131,7 +133,14 @@ function KeplerGlFactory(
     }
 
     _loadMapStyle = () => {
-      [...this.props.mapStyles, ...Object.values(DEFAULT_MAP_STYLES)].forEach(
+      const defaultStyles = Object.values(this.props.mapStyle.mapStyles);
+      // add id to custom map styles if not given
+      const customeStyles = (this.props.mapStyles || []).map(ms => ({
+        ...ms,
+        id: ms.id || generateHashId()
+      }));
+
+      [...customeStyles, ...defaultStyles].forEach(
         style => {
           if (style.style) {
             this.props.mapStyleActions.loadMapStyles({

--- a/src/reducers/map-style.js
+++ b/src/reducers/map-style.js
@@ -22,6 +22,7 @@ import {handleActions} from 'redux-actions';
 
 // Actions
 import ActionTypes from 'constants/action-types';
+import {DEFAULT_MAP_STYLES} from 'constants/default-settings';
 
 import {
   getInitialInputStyle,
@@ -47,7 +48,10 @@ const getDefaultState = () => {
     styleType,
     visibleLayerGroups,
     topLayerGroups,
-    mapStyles: {},
+    mapStyles: DEFAULT_MAP_STYLES.reduce((accu, curr) => ({
+      ...accu,
+      [curr.id]: curr
+    }), {}),
     // save mapbox access token
     mapboxApiAccessToken: null,
     inputStyle: getInitialInputStyle()


### PR DESCRIPTION
- Add default `mapStyles` to map style reducer initial state
- So that they can be customized at reducer initialization by calling `keplerGlReducer.intialState`