### PR TITLE
Fix broken README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ overridden by the latest instance and reset to a blank state.
 
 - Default: `undefined`
 
-You can create a free account at [www.mapbox.com](www.mapbox.com) and create a token at [www.mapbox.com/account/access-tokens](www.mapbox.com/account/access-tokens)
+You can create a free account at [www.mapbox.com](https://www.mapbox.com) and create a token at [www.mapbox.com/account/access-tokens](https://www.mapbox.com/account/access-tokens)
 
 ##### `getState` (Function, optional)
 


### PR DESCRIPTION
**Problem** - The links going out to Mapbox in the README.md file were not formatted properly. This caused you to see the Github 404 page instead of being directed to the proper Mapbox locations.

This was an easy fix and easier to test. Let me know if you all need anything else with this pull request.