### PR TITLE
[Bug] Avoid repeatedly calling HIDE_EXPORT_DROPDOWN 

### DIFF
--- a/src/components/side-panel/panel-dropdown.js
+++ b/src/components/side-panel/panel-dropdown.js
@@ -29,7 +29,9 @@ class PanelDropdown extends Component {
   };
 
   handleClickOutside = (e) => {
-    this.props.onClose(e);
+    if (typeof this.props.onClose === 'function') {
+      this.props.onClose(e);
+    }
   };
 
   render() {

--- a/src/components/side-panel/panel-header.js
+++ b/src/components/side-panel/panel-header.js
@@ -158,7 +158,7 @@ export const SaveExportDropdown = ({
 }) => {
   return (
     <StyledPanelDropdown show={show} className="save-export-dropdown">
-      <PanelDropdown onClose={onClose} className="save-export-dropdown__inner">
+      <PanelDropdown onClose={show ? onClose : null} className="save-export-dropdown__inner">
         <PanelItem
           label="Export Image"
           onClickHandler={onExportImage}


### PR DESCRIPTION
- Avoid calling onClose when header dropdown panel is not shown