### PR TITLE
Refactored unused & uninitialized code

### DIFF
--- a/src/components/side-panel/interaction-panel/interaction-panel.js
+++ b/src/components/side-panel/interaction-panel/interaction-panel.js
@@ -74,7 +74,6 @@ export default class InteractionPanel extends Component {
           <TooltipConfig
             datasets={datasets}
             config={config.config}
-            width={this.state.innerPanelWidth}
             onChange={onChange}
           />
         );
@@ -121,7 +120,7 @@ export default class InteractionPanel extends Component {
   }
 }
 
-const TooltipConfig = ({config, datasets, width, onChange}) => (
+const TooltipConfig = ({config, datasets, onChange}) => (
   <div>
     {Object.keys(config.fieldsToShow).map(dataId => (
       <SidePanelSection key={dataId}>


### PR DESCRIPTION
Removed non-initialized state field `innerPanelWidth` and removed the argument `width` from `ToolTipConfig` since it is not used there.