### PR TITLE
Fix z-fighting issue between text label and scatter plot

### DIFF
--- a/src/components/map/map-legend.js
+++ b/src/components/map/map-legend.js
@@ -121,7 +121,6 @@ const MapLegend = ({layers}) => (
       const enableColorBy = colorChannelConfig.measure;
       const width = DIMENSIONS.mapControl.width - 2 * DIMENSIONS.mapControl.padding;
 
-
       return (
         <StyledMapControlLegend
           className="legend--layer"

--- a/src/layers/point-layer/point-layer.js
+++ b/src/layers/point-layer/point-layer.js
@@ -278,6 +278,10 @@ export default class PointLayer extends Layer {
               getTextAnchor: this.config.textLabel.anchor,
               getText: d => String(d.data[this.config.textLabel.field.tableFieldIndex - 1]),
               getColor: d => this.config.textLabel.color,
+              fp64: this.config.visConfig['hi-precision'],
+              parameters: {
+                depthTest: false
+              },
               updateTriggers: {
                 getPosition: data.getPosition,
                 getPixelOffset: this.config.textLabel.offset,

--- a/src/layers/point-layer/point-layer.js
+++ b/src/layers/point-layer/point-layer.js
@@ -246,8 +246,8 @@ export default class PointLayer extends Layer {
         id: this.id,
         opacity: this.config.visConfig.opacity,
         pickable: true,
-        // parameters
         parameters: {
+          // circles will be flat on the map when the altitude column is not used
           depthTest: this.config.columns.altitude.fieldIdx > -1
         },
 
@@ -280,6 +280,7 @@ export default class PointLayer extends Layer {
               getColor: d => this.config.textLabel.color,
               fp64: this.config.visConfig['hi-precision'],
               parameters: {
+                // text will always show on top of all layers
                 depthTest: false
               },
               updateTriggers: {

--- a/src/layers/point-layer/point-layer.js
+++ b/src/layers/point-layer/point-layer.js
@@ -248,7 +248,7 @@ export default class PointLayer extends Layer {
         pickable: true,
         // parameters
         parameters: {
-          depthTest: mapState.dragRotate
+          depthTest: this.config.columns.altitude.fieldIdx > -1
         },
 
         updateTriggers: {


### PR DESCRIPTION
 - Enable fp64
 - Turn off depth test for text layer to avoid z-fighting
 - Turn off depth test for scatterplot layer when altitude column doesn't exist
 - Fix lint warning in map-legend.js (extra line)