### PR TITLE
Scan through all text labels to get the entire character set

### DIFF
--- a/src/layers/point-layer/point-layer.js
+++ b/src/layers/point-layer/point-layer.js
@@ -22,6 +22,7 @@ import Layer from '../base-layer';
 import memoize from 'lodash.memoize';
 import {TextLayer} from 'deck.gl';
 import ScatterplotBrushingLayer from 'deckgl-layers/scatterplot-brushing-layer/scatterplot-brushing-layer';
+import uniq from 'lodash.uniq';
 import {hexToRgb} from 'utils/color-utils';
 import PointLayerIcon from './point-layer-icon';
 import {DEFAULT_LAYER_COLOR} from 'constants/default-settings';
@@ -34,6 +35,10 @@ export const pointPosAccessor = ({lat, lng, altitude}) => d => [
 
 export const pointPosResolver = ({lat, lng, altitude}) =>
   `${lat.fieldIdx}-${lng.fieldIdx}-${altitude ? altitude.fieldIdx : 'z'}`;
+
+export const pointLabelAccessor = textLabel => d => String(d.data[textLabel.field.tableFieldIndex - 1]);
+export const pointLabelResolver = textLabel => textLabel.field && textLabel.field.tableFieldIndex;
+
 export const pointRequiredColumns = ['lat', 'lng'];
 export const pointOptionalColumns = ['altitude'];
 
@@ -54,6 +59,7 @@ export default class PointLayer extends Layer {
 
     this.registerVisConfig(pointVisConfigs);
     this.getPosition = memoize(pointPosAccessor, pointPosResolver);
+    this.getText = memoize(pointLabelAccessor, pointLabelResolver);
   }
 
   get type() {
@@ -142,6 +148,7 @@ export default class PointLayer extends Layer {
       sizeField,
       sizeScale,
       sizeDomain,
+      textLabel,
       visConfig: {radiusRange, fixedRadius, colorRange}
     } = this.config;
 
@@ -191,6 +198,21 @@ export default class PointLayer extends Layer {
       }, []);
     }
 
+    // get all distinct characters in the text labels
+    const getText = this.getText(textLabel);
+    let labelCharacterSet;
+    if (
+      oldLayerData &&
+      oldLayerData.labelCharacterSet &&
+      opt.sameData &&
+      oldLayerData.getText === getText
+    ) {
+      labelCharacterSet = oldLayerData.labelCharacterSet
+    } else {
+      const textLabels = textLabel.field ? data.map(getText) : [];
+      labelCharacterSet = uniq(textLabels.join(''));
+    }
+
     const getRadius = rScale ? d =>
       this.getEncodedChannelValue(rScale, d.data, sizeField) : 1;
 
@@ -199,9 +221,11 @@ export default class PointLayer extends Layer {
 
     return {
       data,
+      labelCharacterSet,
       getPosition,
       getColor,
-      getRadius
+      getRadius,
+      getText
     };
   }
 
@@ -276,13 +300,14 @@ export default class PointLayer extends Layer {
               getPixelOffset: this.config.textLabel.offset,
               getSize: this.config.textLabel.size,
               getTextAnchor: this.config.textLabel.anchor,
-              getText: d => String(d.data[this.config.textLabel.field.tableFieldIndex - 1]),
+              getText: data.getText,
               getColor: d => this.config.textLabel.color,
               fp64: this.config.visConfig['hi-precision'],
               parameters: {
                 // text will always show on top of all layers
                 depthTest: false
               },
+              characterSet: data.labelCharacterSet,
               updateTriggers: {
                 getPosition: data.getPosition,
                 getPixelOffset: this.config.textLabel.offset,

--- a/test/node/layer-tests/point-layer-specs.js
+++ b/test/node/layer-tests/point-layer-specs.js
@@ -111,8 +111,8 @@ test('#PointLayer -> formatLayerData', t => {
 
         t.deepEqual(
           Object.keys(layerData),
-          ['data', 'getPosition', 'getColor', 'getRadius'],
-          'layerData should have 3 keys'
+          ['data', 'labelCharacterSet', 'getPosition', 'getColor', 'getRadius', 'getText'],
+          'layerData should have 6 keys'
         );
         t.deepEqual(
           layerData.data,
@@ -201,8 +201,8 @@ test('#PointLayer -> formatLayerData', t => {
         );
         t.deepEqual(
           Object.keys(layerData),
-          ['data', 'getPosition', 'getColor', 'getRadius'],
-          'layerData should have 4 keys'
+          ['data', 'labelCharacterSet', 'getPosition', 'getColor', 'getRadius', 'getText'],
+          'layerData should have 6 keys'
         );
         t.deepEqual(
           layerData.data,


### PR DESCRIPTION
Fix issue #238 
Scan through all text labels to get the entire character set, and pass the character set into TextLayer.

Demo - show tree emoji in the label:
<img width="1673" alt="screen shot 2018-10-05 at 12 38 33 am" src="https://user-images.githubusercontent.com/3599601/46522555-effea680-c837-11e8-98fc-d0ff357bfc43.png">
