### PR TITLE
Fixing global color issue #130 for the heat map

### DIFF
--- a/src/layers/heatmap-layer/heatmap-layer.js
+++ b/src/layers/heatmap-layer/heatmap-layer.js
@@ -48,7 +48,7 @@ export const heatmapVisConfigs = {
 const heatmapDensity = (colorRange) => {
   const scaleFunction = SCALE_FUNC.quantize;
 
-  const colors = ['#000000', ...colorRange.colors]
+  const colors = ['#000000', ...colorRange.colors];
 
   const scale = scaleFunction()
     .domain([0, 1])
@@ -62,8 +62,8 @@ const heatmapDensity = (colorRange) => {
       `rgb(${hexToRgb(level).join(',')})` // color
     ]
   }, []);
-  colorDensity[1] = "rgba(0,0,0,0)"
-  return colorDensity
+  colorDensity[1] = 'rgba(0,0,0,0)';
+  return colorDensity;
 };
 
 const shouldRebuild = (sameData, sameConfig) => !(sameData && sameConfig);

--- a/src/layers/heatmap-layer/heatmap-layer.js
+++ b/src/layers/heatmap-layer/heatmap-layer.js
@@ -46,14 +46,15 @@ export const heatmapVisConfigs = {
  * ]
  */
 const heatmapDensity = (colorRange) => {
-
   const scaleFunction = SCALE_FUNC.quantize;
+
+  const colors = ['#000000', ...colorRange.colors]
 
   const scale = scaleFunction()
     .domain([0, 1])
-    .range(colorRange.colors);
+    .range(colors);
 
-  return scale.range().reduce((bands, level) => {
+  const colorDensity = scale.range().reduce((bands, level) => {
     const invert = scale.invertExtent(level);
     return [
       ...bands,
@@ -61,6 +62,8 @@ const heatmapDensity = (colorRange) => {
       `rgb(${hexToRgb(level).join(',')})` // color
     ]
   }, []);
+  colorDensity[1] = "rgba(0,0,0,0)"
+  return colorDensity
 };
 
 const shouldRebuild = (sameData, sameConfig) => !(sameData && sameConfig);


### PR DESCRIPTION
For issue #130 👍
The main reason is that map box gl need the first color to have opacity of 0.

I added a color in the beginning of the colors array
replaced that color with rgba(0, 0, 0, 0)