### PR TITLE
Fix auto focus / respect calculated bounds

### DIFF
--- a/src/reducers/map-state-updaters.js
+++ b/src/reducers/map-state-updaters.js
@@ -61,7 +61,7 @@ export const receiveMapConfigUpdater = (state, action) => {
     ...state,
     ...(action.payload.mapState || {}),
     latitude: state.latitude ? state.latitude : latitude,
-    longitude: state.latitude ? state.latitude : longitude,
+    longitude: state.longitude ? state.longitude : longitude,
     zoom: state.zoom ? state.zoom : zoom,
     isSplit,
     ...getMapDimForSplitMap(isSplit, state)

--- a/src/reducers/map-state-updaters.js
+++ b/src/reducers/map-state-updaters.js
@@ -51,12 +51,18 @@ export const togglePerspectiveUpdater = (state, action) => ({
 });
 
 // consider case where you have a split map and user wants to reset
+// Bounds are calculated in updateVisData to focus newLayer if centerMap: true
+// We should respect the calculated bounds here.
 export const receiveMapConfigUpdater = (state, action) => {
-  const {isSplit = false} = action.payload.mapState || {};
+  const {isSplit = false, latitude, longitude, zoom} =
+    action.payload.mapState || {};
 
   return {
     ...state,
     ...(action.payload.mapState || {}),
+    latitude: state.latitude ? state.latitude : latitude,
+    longitude: state.latitude ? state.latitude : longitude,
+    zoom: state.zoom ? state.zoom : zoom,
     isSplit,
     ...getMapDimForSplitMap(isSplit, state)
   };
@@ -79,13 +85,14 @@ function getMapDimForSplitMap(isSplit, state) {
     return {};
   }
 
-  const width = state.isSplit && !isSplit ?
-    // 3. state split: true - isSplit: false
-    // double width
-    state.width * 2
-    // 4. state split: false - isSplit: true
-    // split width
-    : state.width / 2;
+  const width =
+    state.isSplit && !isSplit
+      ? // 3. state split: true - isSplit: false
+        // double width
+        state.width * 2
+      : // 4. state split: false - isSplit: true
+        // split width
+        state.width / 2;
 
   return {
     width


### PR DESCRIPTION
Revision to previous diff, 

Previous diff: 
* Moved the logic of calculating bounds into mapStateUpdaters but this doesn't allow focusing on just the newest data set (and we didn't want to break this)
* Instead focused on the center between all data sets, worse user experience

This diff: 
* Should maintain the same behavior in most of the cases, where this is different is: 
     There is a saved config with some lat/lng in mapState, and data/ config are added at once in one call to addDataToMap with option centerMap: true. What would happen is we would calculate the bounds in `updateVisDataUpdater` to the new layer data, but then overwrite the calculated bounds with those in `map-state-updated - receiveMapConfigUpdater` as it would do `{...mergedConfig, ...parsedConfig}`. 