### PR TITLE
[Bug] Fix missing 3d building layer in image export

### DIFF
--- a/src/components/plot-container.js
+++ b/src/components/plot-container.js
@@ -76,12 +76,12 @@ export default function PlotContainerFactory(MapContainer) {
       this.mapStyleSelector,
       this.resolutionSelector,
       (mapStyle, resolution) => ({
+        ...mapStyle,
         bottomMapStyle: scaleMapStyleByResolution(
           mapStyle.bottomMapStyle,
           resolution
         ),
-        topMapStyle: scaleMapStyleByResolution(mapStyle.topMapStyle, resolution),
-        visibleLayerGroups: mapStyle.visibleLayerGroups
+        topMapStyle: scaleMapStyleByResolution(mapStyle.topMapStyle, resolution)
       })
     );
 


### PR DESCRIPTION
- pass mapStyle to plot container which containers `threeDBuildingColor`