### PR TITLE
[Feat] Single map page

### DIFF
--- a/docs/user-guides/k-save-and-export.md
+++ b/docs/user-guides/k-save-and-export.md
@@ -36,3 +36,11 @@ You can export the current map configuration as a `json` file. This is useful wh
 #### 2.Save and Export Current Map
 
 To save and share your current map, click the __Export Current Map__ check box to export current configuration __AND__ uploaded data in a single `json` file.  **You can load this json file back to kepler.gl by simply drag and drop it in the __Add Data to Map__ dialog.**
+
+### 2.Export current Map as HTML
+
+![Export Map as HTML](https://d1a3f4spazzrp4.cloudfront.net/kepler.gl/documentation/k-save-and-export-5.png "activate interactions")
+
+To save and export your current map as HTML file, click on __Export Map__ and subsequently on __Export__. Your browser will download a new kepler.gl.html that contains both data and configuration. Simply click on the file to visualize your map.
+
+

--- a/docs/user-guides/k-save-and-export.md
+++ b/docs/user-guides/k-save-and-export.md
@@ -42,5 +42,26 @@ To save and share your current map, click the __Export Current Map__ check box t
 ![Export Map as HTML](https://d1a3f4spazzrp4.cloudfront.net/kepler.gl/documentation/k-save-and-export-5.png "activate interactions")
 
 To save and export your current map as HTML file, click on __Export Map__ and subsequently on __Export__. Your browser will download a new kepler.gl.html that contains both data and configuration. Simply click on the file to visualize your map.
+Kepler.gl is providing with a temporary Mapbox token to use in your html file but we strongly recommend to use your own. The provided token has a limited duration and will be periodically replaced with a new one
+without any notification.
+
+#### How to update an exported map token
+In order to edit the mapbox token in your html file you simply need to perform the following steps:
+- [Create a new mapbox token](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/) or use your existing one.
+- Open the kepler.gl.map file with your favorite text editor.
+- Locate the following line in the exported file __kepler.gl.html__:
+```javascript
+  /**
+   * Provide your MapBox Token
+   **/
+  const MAPBOX_TOKEN = 'CURRENT_TOKEN';
+```
+- Replace the current value a new valid token. The code should now look like the following:
+```javascript
+  /**
+   * Provide your MapBox Token   
+   **/
+  const MAPBOX_TOKEN = 'pk.eyJ1IjoidWJlcmRh...';
+```
 
 

--- a/examples/demo-app/src/actions.js
+++ b/examples/demo-app/src/actions.js
@@ -359,7 +359,8 @@ export function exportFileToCloud(handlerName = 'dropbox') {
     // extract data from kepler
     const data = KeplerGlSchema.save(getState().demo.keplerGl.map);
     const newBlob = new Blob([JSON.stringify(data)], {type: 'application/json'});
-    const file = new File([newBlob], `kepler.gl/keplergl_${generateHashId(6)}.json`);
+    const file = new File([newBlob], `keplergl_${generateHashId(6)}.json`);
+    // We are gonna pass the correct auth token to init the cloud provider
     dispatch(setPushingFile(true, {filename: file.name, status: 'uploading', metadata: null}));
     authHandler.uploadFile({blob: file, isPublic: true, authHandler})
     // need to perform share as well

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -25,7 +25,6 @@ import styled, {ThemeProvider}  from 'styled-components';
 import window from 'global/window';
 import {connect} from 'react-redux';
 import {theme} from 'kepler.gl/styles';
-import {setExportMapboxAccessToken} from 'kepler.gl/actions';
 import Banner from './components/banner';
 import Announcement from './components/announcement';
 import {replaceLoadDataModal} from './factories/load-data-modal';
@@ -110,9 +109,6 @@ class App extends Component {
   }
 
   componentDidMount() {
-    // we set a mapbox token to support export single file functionality
-    this.props.dispatch(setExportMapboxAccessToken(AUTH_TOKENS.EXPORT_MAPBOX_TOKEN));
-
     // delay zs to show the banner
     // if (!window.localStorage.getItem(BannerKey)) {
     //   window.setTimeout(this._showBanner, 3000);

--- a/examples/demo-app/src/constants/default-settings.js
+++ b/examples/demo-app/src/constants/default-settings.js
@@ -101,5 +101,11 @@ export const DEFAULT_LOADING_METHOD = LOADING_METHODS[0];
 export const DEFAULT_CLOUD_PROVIDER = 'dropbox';
 
 export const DEFAULT_FEATURE_FLAGS = {
-  cloudStorage: false
+  cloudStorage: true
+};
+
+export const AUTH_TOKENS = {
+  MAPBOX_TOKEN: process.env.MapboxAccessToken, // eslint-disable-line
+  DROPBOX_CLIEND_ID: process.env.DropboxClientId, // eslint-disable-line
+  EXPORT_MAPBOX_TOKEN: process.env.MapboxExportToken, // eslint-disable-line
 };

--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -35,7 +35,12 @@ import {
   SET_SAMPLE_LOADING_STATUS
 } from '../actions';
 
-import {DEFAULT_FEATURE_FLAGS, DEFAULT_LOADING_METHOD, LOADING_METHODS} from '../constants/default-settings';
+import {
+  AUTH_TOKENS,
+  DEFAULT_FEATURE_FLAGS,
+  DEFAULT_LOADING_METHOD,
+  LOADING_METHODS
+} from '../constants/default-settings';
 import {generateHashId} from '../utils/strings';
 
 // INITIAL_APP_STATE
@@ -82,7 +87,16 @@ export const appReducer = handleActions({
 // to mimic the reducer state of kepler.gl website
 const demoReducer = combineReducers({
   // mount keplerGl reducer
-  keplerGl: keplerGlReducer,
+  keplerGl: keplerGlReducer.initialState({
+    // In order to provide single file export functionality
+    // we are going to set the mapbox access token to be used
+    // in the exported file
+    uiState: {
+      exportHtml: {
+        exportMapboxAccessToken: AUTH_TOKENS.EXPORT_MAPBOX_TOKEN
+      }
+    }
+  }),
   app: appReducer,
   sharing: sharingReducer
 });

--- a/examples/demo-app/src/utils/cloud-providers/dropbox.js
+++ b/examples/demo-app/src/utils/cloud-providers/dropbox.js
@@ -20,15 +20,25 @@
 
 // DROPBOX
 import {Dropbox} from 'dropbox';
+import window from 'global/window';
 import {parseQueryString} from '../url';
-import window from 'global/window'
 import DropboxIcon from '../../components/icons/dropbox-icon';
 
-const DROPBOX_CLIEND_ID = process.env.DropboxClientId;
 const NAME = 'dropbox';
 const DOMAIN = 'www.dropbox.com';
 const CORS_FREE_DOMAIN = 'dl.dropboxusercontent.com';
-const dropbox = new Dropbox({clientId: DROPBOX_CLIEND_ID});
+const dropbox = new Dropbox();
+
+/**
+ * Set the auth toke to be used with dropbox client
+ * @param authToken
+ */
+function setAuthToken(authToken) {
+  if (dropbox.getClientId()) {
+    return;
+  }
+  dropbox.setClientId(authToken);
+}
 
 /**
  * Generate auth link url to open to be used to handle OAuth2
@@ -65,7 +75,7 @@ function getAccessTokenFromLocation(location) {
  */
 function uploadFile({blob, name, isPublic = true}) {
   const promise = dropbox.filesUpload({
-    path: `/keplergl/${blob.name || name}`,
+    path: blob.name || name,
     contents: blob
   });
 
@@ -150,9 +160,10 @@ function getAccessToken() {
 // All cloud-providers providers must implement the following properties
 export default {
   name: NAME,
+  getAccessToken,
   getAccessTokenFromLocation,
   handleLogin,
-  uploadFile,
-  getAccessToken,
-  icon: DropboxIcon
+  icon: DropboxIcon,
+  setAuthToken,
+  uploadFile
 };

--- a/examples/demo-app/src/utils/cloud-providers/index.js
+++ b/examples/demo-app/src/utils/cloud-providers/index.js
@@ -19,6 +19,10 @@
 // THE SOFTWARE.
 
 import DropboxHandler from './dropbox';
+import {AUTH_TOKENS} from '../../constants/default-settings';
+
+// configure all clients with the right configuration
+DropboxHandler.setAuthToken(AUTH_TOKENS.DROPBOX_CLIEND_ID);
 
 export const CLOUD_PROVIDERS = {
   [DropboxHandler.name]: DropboxHandler

--- a/examples/demo-app/webpack.config.js
+++ b/examples/demo-app/webpack.config.js
@@ -72,7 +72,11 @@ const CONFIG = {
 
   // Optional: Enables reading mapbox and dropbox client token from environment variable
   plugins: [
-    new webpack.EnvironmentPlugin(['MapboxAccessToken', 'DropboxClientId'])
+    new webpack.EnvironmentPlugin([
+      'MapboxAccessToken',
+      'DropboxClientId',
+      'MapboxExportToken'
+    ])
   ]
 };
 

--- a/examples/umd-client/index.html
+++ b/examples/umd-client/index.html
@@ -33,6 +33,7 @@
      * This will be used in app.js (imported later)
      * */
     const MAPBOX_TOKEN = 'PROVIDE_MAPBOX_TOKEN';
+    const WARNING_MESSAGE = 'Please Provide a Mapbox Token in order to use Kepler.gl. Edit this file and fill out MAPBOX_TOKEN with your access key';
   </script>
 
 </head>
@@ -44,7 +45,13 @@
 
   <!-- Load our React component. -->
   <script>
-    const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken) {
+    const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken, warningMessage) {
+
+      /* Validate Mapbox Token */
+      if ((mapboxToken || '') === '' || mapboxToken === 'PROVIDE_MAPBOX_TOKEN') {
+        alert(warningMessage)
+      }
+
       /** STORE **/
       const reducers = redux.combineReducers({
         // mount keplerGl reducer
@@ -96,7 +103,7 @@
       };
 
       /** END COMPONENTS **/
-    }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN));
+    }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN, WARNING_MESSAGE));
 
     // Render kepler in the html page
     map.render();

--- a/examples/umd-client/index.html
+++ b/examples/umd-client/index.html
@@ -101,6 +101,7 @@
     // Render kepler in the html page
     map.render();
   </script>
+
   <!-- The next script will show how to interact directly with Kepler map store -->
   <script>
     /**

--- a/examples/umd-client/index.html
+++ b/examples/umd-client/index.html
@@ -30,8 +30,7 @@
   <script>
     /**
      * Provide your MapBox Token
-     * This will be used in app.js (imported later)
-     * */
+     **/
     const MAPBOX_TOKEN = 'PROVIDE_MAPBOX_TOKEN';
     const WARNING_MESSAGE = 'Please Provide a Mapbox Token in order to use Kepler.gl. Edit this file and fill out MAPBOX_TOKEN with your access key';
   </script>

--- a/examples/umd-client/index.html
+++ b/examples/umd-client/index.html
@@ -45,36 +45,43 @@
 
   <!-- Load our React component. -->
   <script>
-    const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken, warningMessage) {
+    /* Validate Mapbox Token */
+    if ((MAPBOX_TOKEN || '') === '' || MAPBOX_TOKEN === 'PROVIDE_MAPBOX_TOKEN') {
+      alert(WARNING_MESSAGE);
+    }
 
-      /* Validate Mapbox Token */
-      if ((mapboxToken || '') === '' || mapboxToken === 'PROVIDE_MAPBOX_TOKEN') {
-        alert(warningMessage)
-      }
-
-      /** STORE **/
-      const reducers = redux.combineReducers({
+    /** STORE **/
+    const reducers = (function createReducers(redux, keplerGl) {
+      return redux.combineReducers({
         // mount keplerGl reducer
         keplerGl: keplerGl.keplerGlReducer
       });
+    }(Redux, KeplerGl));
 
-      const middlewares = keplerGl.enhanceReduxMiddleware([
+    const middleWares = (function createMiddlewares(keplerGl) {
+      return keplerGl.enhanceReduxMiddleware([
         // Add other middlewares here
       ]);
+    }(KeplerGl));
 
-      const enhancers = redux.applyMiddleware(...middlewares);
+    const enhancers = (function craeteEnhancers(redux, middles) {
+      return redux.applyMiddleware(...middles);
+    }(Redux, middleWares));
 
+    const store = (function createStore(redux, enhancers) {
       const initialState = {};
 
-      const store = redux.createStore(
+      return redux.createStore(
         reducers,
         initialState,
         redux.compose(enhancers)
       );
-      /** END STORE **/
+    }(Redux, enhancers));
+    /** END STORE **/
 
-      /** COMPONENTS **/
-      function App(props) {
+    /** COMPONENTS **/
+    const KeplerElement = (function (react, keplerGl, mapboxToken) {
+      return function(props) {
         return react.createElement(
           'div',
           {style: {position: 'absolute', left: 0, width: '100vw', height: '100vh'}},
@@ -89,24 +96,22 @@
           )
         )
       }
+    }(React, KeplerGl, MAPBOX_TOKEN));
 
-      return {
-        render: () => {
-          reactDOM.render(react.createElement(
-            reactRedux.Provider,
-            {store},
-            react.createElement(App, null)
-          ), document.getElementById('app'));
-        },
-        // By returning store we can interact with the map, e.g. add data
-        store
-      };
+    const app = (function createReactReduxProvider(react, reactRedux, KeplerElement) {
+      return react.createElement(
+        reactRedux.Provider,
+        {store},
+        react.createElement(KeplerElement, null)
+      )
+    }(React, ReactRedux, KeplerElement));
+    /** END COMPONENTS **/
 
-      /** END COMPONENTS **/
-    }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN, WARNING_MESSAGE));
+    /** Render **/
+    (function render(react, reactDOM, app) {
+      reactDOM.render(app, document.getElementById('app'));
+    }(React, ReactDOM, app));
 
-    // Render kepler in the html page
-    map.render();
   </script>
 
   <!-- The next script will show how to interact directly with Kepler map store -->
@@ -115,9 +120,9 @@
      * Customize map.
      * Interact with map store to customize data and behavior
      */
-    (function customize(keplerGl, map) {
-      // map.store.dispatch(keplerGl.toggleSplitMap());
-    }(KeplerGl, map))
+    (function customize(keplerGl, store) {
+      // store.dispatch(keplerGl.toggleSplitMap());
+    }(KeplerGl, store))
   </script>
 </body>
 </html>

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -67,7 +67,11 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR) {
     },
     // Optional: Enables reading mapbox token from environment variable
     plugins: [
-      new webpack.EnvironmentPlugin(['MapboxAccessToken', 'DropboxClientId'])
+      new webpack.EnvironmentPlugin([
+        'MapboxAccessToken',
+        'DropboxClientId',
+        'MapboxExportToken'
+      ])
     ]
   };
 }

--- a/src/actions/ui-state-actions.js
+++ b/src/actions/ui-state-actions.js
@@ -200,7 +200,7 @@ export const setExportDataType = createAction(
 /**
  * Whether to export filtered data, `true` or `false`
  * @memberof uiStateActions
- * @param {bollean} payload - set `true` to ony export filtered data
+ * @param {boolean} payload - set `true` to ony export filtered data
  * @public
  */
 export const setExportFiltered = createAction(
@@ -218,6 +218,17 @@ export const setExportData = createAction(
 );
 
 /**
+ * Whether we export a mapbox access token used to create a single map html file
+ * @memberof uiStateActions
+ * @param {string} payload - mapbox access token
+ * @public
+ */
+export const setExportMapboxAccessToken = createAction(
+  ActionTypes.SET_EXPORT_MAPBOX_ACCESS_TOKEN,
+  payload => payload
+);
+
+/**
  * This declaration is needed to group actions in docs
  */
 /**
@@ -229,5 +240,5 @@ export const setExportData = createAction(
  * @public
  */
 /* eslint-disable no-unused-vars */
-const uiStateActions = null
+const uiStateActions = null;
 /* eslint-enable no-unused-vars */

--- a/src/components/common/icons/index.js
+++ b/src/components/common/icons/index.js
@@ -46,6 +46,7 @@ export {default as Layers} from './layers';
 export {default as LeftArrow} from './left-arrow';
 export {default as Legend} from './legend';
 export {default as LineChart} from './line-chart';
+export {default as Map} from './map';
 export {default as Minus} from './minus';
 export {default as Messages} from './messages';
 export {default as Pause} from './pause';

--- a/src/components/common/icons/map.js
+++ b/src/components/common/icons/map.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import Base from './base';
+
+class MapIcon extends Component {
+  static propTypes = {
+    /** Set the height of the icon, ex. '16px' */
+    height: PropTypes.string,
+    colors: PropTypes.arrayOf(PropTypes.string)
+  };
+
+  static defaultProps = {
+    height: '16px',
+    predefinedClassName: 'data-ex-icons-add',
+    totalColor: 1
+  };
+
+  render() {
+    return (
+      <Base viewBox={"0 0 602 602"} {...this.props}>
+        <g>
+          <path
+            d="M573.864,323.679l25.6-201.737L409.988,50.046L197.993,151.289L0,67.678l27.935,220.105L2.223,506.009l208.665,39.135
+			l200.136-38.125l189.865,43.823L573.864,323.679z M210.855,522.625L26.64,488.076l23.732-199.335L26.803,103.007l171.761,72.543
+			L410.987,74.083l164.331,62.361l-23.755,187.142l23.648,198.602l-163.764-37.782L210.855,522.625z"/>
+          <path
+            d="M506.021,405.449c-5.509,0-10.604,1.596-15.049,4.167c-17.531-12.832-35.583-27.904-36.47-47.735
+			c-1.217-27.195,15.439-53.227-3.623-78.182c-18.625-24.382-66.301-7.944-84.73-26.264c2.873-4.617,4.593-10.01,4.593-15.844
+			c0-16.671-13.519-30.192-30.187-30.192c-16.68,0-30.192,13.515-30.192,30.192c0,9.561,4.534,17.98,11.467,23.513
+			c-2.907,7.358-4.729,15.167-5.048,23.141c-0.496,12.596,3.121,25.126,0.391,37.634c-2.252,10.391-16.875,9.729-24.757,9.788
+			c-19.875,0.177-48.202-3.57-61.023,10.462c-3.783-2.843-8.207-4.812-13.077-5.621c-2.87-25.848,2.098-51.102-20.824-70.985
+			c-14.736-12.794-38.846-18.344-52.438-32.719c2.873-4.619,4.61-10.031,4.61-15.871c0-16.674-13.515-30.198-30.189-30.198
+			c-16.668,0-30.192,13.515-30.192,30.198c0,16.668,13.515,30.183,30.192,30.183c5.562,0,10.707-1.604,15.179-4.229
+			c10.048,10.083,23.915,16.784,36.892,23.56c16.529,8.627,28.844,19.698,31.108,39.283c1.241,10.734,0.762,21.291,1.46,31.854
+			c-12.135,3.918-20.978,15.16-20.978,28.602c0,16.681,13.515,30.192,30.195,30.192c16.668,0,30.189-13.512,30.189-30.192
+			c0-3.942-0.81-7.701-2.189-11.159c10.024-18.063,56.066-5.745,73.423-11.55c12.644-4.238,17.13-16.083,18.247-28.365
+			c1.063-11.473-2.637-22.757-0.91-34.283c0.686-4.69,1.867-9.224,3.439-13.55c1.644,0.271,3.311,0.502,5.024,0.502
+			c5.308,0,10.22-1.489,14.559-3.904c18.684,18.713,55.768,6.174,79.328,20.271c28.017,16.754-0.792,64.046,8.051,89.309
+			c6.123,17.472,22.13,30.499,37.994,42.232c-2.902,4.64-4.664,10.084-4.664,15.953c0,16.681,13.507,30.192,30.198,30.192
+			c16.657,0,30.192-13.512,30.192-30.192C536.213,418.979,522.689,405.449,506.021,405.449z"/>
+        </g>
+      </Base>
+    );
+  }
+}
+
+export default MapIcon;

--- a/src/components/modal-container.js
+++ b/src/components/modal-container.js
@@ -36,7 +36,10 @@ import ExportImageModalFactory from './modals/export-image-modal';
 import ExportDataModalFactory from './modals/export-data-modal';
 import ExportConfigModalFactory from './modals/export-config-modal';
 import AddMapStyleModalFactory from './modals/add-map-style-modal';
+import ExportMapModalFactory from './modals/export-map-modal';
 
+// Template
+import {exportMapToHTML} from 'templates/export-map';
 import {
   ADD_DATA_ID,
   DATA_TABLE_ID,
@@ -48,6 +51,7 @@ import {
   EXPORT_CONFIG_ID,
   ADD_MAP_STYLE_ID
 } from 'constants/default-settings';
+import {EXPORT_MAP_ID} from '../constants/default-settings';
 
 const DataTableModalStyle = css`
   height: 85%;
@@ -73,6 +77,7 @@ ModalContainerFactory.deps = [
   ExportImageModalFactory,
   ExportDataModalFactory,
   ExportConfigModalFactory,
+  ExportMapModalFactory,
   AddMapStyleModalFactory
 ];
 
@@ -83,6 +88,7 @@ export default function ModalContainerFactory(
   ExportImageModal,
   ExportDataModal,
   ExportConfigModal,
+  ExportMapModal,
   AddMapStyleModal
 ) {
   class ModalWrapper extends Component {
@@ -180,6 +186,19 @@ export default function ModalContainerFactory(
       );
 
       this._closeModal();
+    };
+
+    _onExportMap = () => {
+      // we are saving both data and config together
+      // TODO: storing a large amount of data in html could be a limitation
+      // but it will work for now as first version
+      const dump = KeplerGlSchema.save(this.props);
+
+      this._downloadFile(
+        exportMapToHTML(dump),
+        'text/html',
+        'kepler.gl.html'
+      );
     };
 
     /* eslint-disable complexity */
@@ -290,7 +309,6 @@ export default function ModalContainerFactory(
             break;
 
           case EXPORT_DATA_ID:
-
             template = (
               <ExportDataModal
                 {...uiState.exportData}
@@ -359,6 +377,23 @@ export default function ModalContainerFactory(
                 large: true,
                 disabled: !mapStyle.inputStyle.style,
                 children: 'Add Style'
+              }
+            };
+            break;
+
+          case EXPORT_MAP_ID:
+            template = (
+              <ExportMapModal />
+            );
+            modalProps = {
+              close: false,
+              title: 'Export map',
+              footer: true,
+              onCancel: this._closeModal,
+              onConfirm: this._onExportMap,
+              confirmButton: {
+                large: true,
+                children: 'Export'
               }
             };
             break;

--- a/src/components/modal-container.js
+++ b/src/components/modal-container.js
@@ -49,9 +49,9 @@ import {
   EXPORT_DATA_TYPE,
   EXPORT_IMAGE_ID,
   EXPORT_CONFIG_ID,
+  EXPORT_MAP_ID,
   ADD_MAP_STYLE_ID
 } from 'constants/default-settings';
-import {EXPORT_MAP_ID} from '../constants/default-settings';
 
 const DataTableModalStyle = css`
   height: 85%;

--- a/src/components/modal-container.js
+++ b/src/components/modal-container.js
@@ -192,10 +192,15 @@ export default function ModalContainerFactory(
       // we are saving both data and config together
       // TODO: storing a large amount of data in html could be a limitation
       // but it will work for now as first version
-      const dump = KeplerGlSchema.save(this.props);
+      const {uiState} = this.props;
+
+      const data = {
+        ...KeplerGlSchema.save(this.props),
+        mapboxApiAccessToken: uiState.exportHtml.exportMapboxAccessToken
+      };
 
       this._downloadFile(
-        exportMapToHTML(dump),
+        exportMapToHTML(data),
         'text/html',
         'kepler.gl.html'
       );
@@ -382,8 +387,12 @@ export default function ModalContainerFactory(
             break;
 
           case EXPORT_MAP_ID:
+
             template = (
-              <ExportMapModal />
+              <ExportMapModal
+                exportHtml={uiState.exportHtml}
+                onExportMapboxAccessToken={this.props.uiStateActions.setExportMapboxAccessToken}
+              />
             );
             modalProps = {
               close: false,

--- a/src/components/modals/export-map-modal.js
+++ b/src/components/modals/export-map-modal.js
@@ -72,12 +72,12 @@ const ExportMapModal = ({
         Export your map into a single html file
       </div>
       <div className="subtitle">
-        You will be able to save your configuration and data into a single file and download it on your device.
+        You will be able to save your map into an interactive html file.
       </div>
 
       <StyledSection>
         <div>
-          Please provide your Mapbox access token
+          Please provide your <a style={{textDecorationLine: 'underline'}} href="https://docs.mapbox.com/help/how-mapbox-works/access-tokens/">Mapbox access token</a>
         </div>
         <StyledInput
           onChange={e => onExportMapboxAccessToken(e.target.value)}

--- a/src/components/modals/export-map-modal.js
+++ b/src/components/modals/export-map-modal.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const StyledExportMapModal = styled.div`
@@ -36,9 +37,35 @@ const StyledExportMapModal = styled.div`
   }
 `;
 
-const propTypes = { /* No required Props for now */};
+const StyledSection = styled.div`
+  margin: 24px 0;
+`;
 
-export const ExportMapModal = () => (
+const StyledInput = styled.input`
+  width: 100%;
+  padding: ${props => props.theme.inputPadding};
+  color: ${props => props.error ? 'red' : props.theme.titleColorLT};
+  height: ${props => props.theme.inputBoxHeight};
+  outline: 0;
+  font-size: ${props => props.theme.inputFontSize};
+  
+  :active,
+  :focus,
+  &.focus,
+  &.active {
+    outline: 0;
+  }
+`;
+
+const propTypes = {
+  exportHtml: PropTypes.object,
+  onExportMapboxAccessToken: PropTypes.func.isRequired
+};
+
+const ExportMapModal = ({
+  exportHtml,
+  onExportMapboxAccessToken
+}) => (
   <StyledExportMapModal>
     <div className="export-map-modal">
       <div className="title">
@@ -47,6 +74,18 @@ export const ExportMapModal = () => (
       <div className="subtitle">
         You will be able to save your configuration and data into a single file and download it on your device.
       </div>
+
+      <StyledSection>
+        <div>
+          Please provide your Mapbox access token
+        </div>
+        <StyledInput
+          onChange={e => onExportMapboxAccessToken(e.target.value)}
+          type="text"
+          placeholder="Mapbox access token"
+          value={exportHtml ? exportHtml.exportMapboxAccessToken : ''}
+        />
+      </StyledSection>
     </div>
   </StyledExportMapModal>
 );

--- a/src/components/modals/export-map-modal.js
+++ b/src/components/modals/export-map-modal.js
@@ -19,29 +19,39 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import FileUpload from 'components/common/file-uploader/file-upload';
-
-const StyledLoadDataModal = styled.div`
+const StyledExportMapModal = styled.div`
   padding: ${props => props.theme.modalPadding};
+
+  .title {
+    font-weight: 500;
+    color: ${props => props.theme.textColorLT};
+    font-size: 12px;
+  }
+
+  .description {
+    color: ${props => props.theme.textColor};
+    font-size: 11px;
+  }
 `;
 
-const propTypes = {
-  // call backs
-  onFileUpload: PropTypes.func.isRequired
-};
+const propTypes = { /* No required Props for now */};
 
-export const LoadDataModal = props => (
-  <StyledLoadDataModal>
-    <div className="load-data-modal">
-      <FileUpload onFileUpload={props.onFileUpload} />
+export const ExportMapModal = () => (
+  <StyledExportMapModal>
+    <div className="export-map-modal">
+      <div className="title">
+        Export your map into a single html file
+      </div>
+      <div className="subtitle">
+        You will be able to save your configuration and data into a single file and download it on your device.
+      </div>
     </div>
-  </StyledLoadDataModal>
+  </StyledExportMapModal>
 );
 
-LoadDataModal.propTypes = propTypes;
+ExportMapModal.propTypes = propTypes;
 
-const loadDataModalFactory = () => LoadDataModal;
-export default loadDataModalFactory;
+const exportMapModalFactory = () => ExportMapModal;
+export default exportMapModalFactory;

--- a/src/components/modals/export-map-modal.js
+++ b/src/components/modals/export-map-modal.js
@@ -21,6 +21,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import {GITHUB_EXPORT_HTML_MAP, MAPBOX_ACCESS_TOKEN} from 'constants/user-guides';
 
 const StyledExportMapModal = styled.div`
   padding: ${props => props.theme.modalPadding};
@@ -77,7 +78,7 @@ const ExportMapModal = ({
 
       <StyledSection>
         <div>
-          Please provide your <a style={{textDecorationLine: 'underline'}} href="https://docs.mapbox.com/help/how-mapbox-works/access-tokens/">Mapbox access token</a>
+          Please provide your <a style={{textDecorationLine: 'underline'}} href={MAPBOX_ACCESS_TOKEN}>Mapbox access token</a>
         </div>
         <StyledInput
           onChange={e => onExportMapboxAccessToken(e.target.value)}
@@ -85,7 +86,11 @@ const ExportMapModal = ({
           placeholder="Mapbox access token"
           value={exportHtml ? exportHtml.exportMapboxAccessToken : ''}
         />
+        <div>
+          * <a style={{textDecorationLine: 'underline'}} href={GITHUB_EXPORT_HTML_MAP}>How to update an existing map token</a>
+        </div>
       </StyledSection>
+
     </div>
   </StyledExportMapModal>
 );

--- a/src/components/side-panel.js
+++ b/src/components/side-panel.js
@@ -39,6 +39,7 @@ import {
   EXPORT_CONFIG_ID,
   PANELS
 } from 'constants/default-settings';
+import {EXPORT_MAP_ID} from '../constants/default-settings';
 
 const SidePanelContent = styled.div`
   ${props => props.theme.sidePanelScrollBar};
@@ -128,6 +129,8 @@ export default function SidePanelFactory(
 
     _onExportConfig = () => this.props.uiStateActions.toggleModal(EXPORT_CONFIG_ID);
 
+    _onExportMap = () => this.props.uiStateActions.toggleModal(EXPORT_MAP_ID);
+
     render() {
       const {
         appName,
@@ -202,6 +205,7 @@ export default function SidePanelFactory(
               showExportDropdown={uiStateActions.showExportDropdown}
               hideExportDropdown={uiStateActions.hideExportDropdown}
               onExportConfig={this._onExportConfig}
+              onExportMap={this._onExportMap}
               onSaveMap={this.props.onSaveMap}
             />
             <PanelToggle

--- a/src/components/side-panel.js
+++ b/src/components/side-panel.js
@@ -37,9 +37,9 @@ import {
   EXPORT_IMAGE_ID,
   EXPORT_DATA_ID,
   EXPORT_CONFIG_ID,
+  EXPORT_MAP_ID,
   PANELS
 } from 'constants/default-settings';
-import {EXPORT_MAP_ID} from '../constants/default-settings';
 
 const SidePanelContent = styled.div`
   ${props => props.theme.sidePanelScrollBar};

--- a/src/components/side-panel/panel-header.js
+++ b/src/components/side-panel/panel-header.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import {Tooltip} from 'components/common/styled-components';
 import KeplerGlLogo from 'components/common/logo';
-import {CodeAlt, Save, Files, Share, Picture} from 'components/common/icons';
+import {CodeAlt, Save, Files, Share, Picture, Map} from 'components/common/icons';
 import ClickOutsideCloseDropdown from 'components/side-panel/panel-dropdown';
 
 const StyledPanelHeader = styled.div.attrs({
@@ -154,6 +154,7 @@ export const SaveExportDropdown = ({
   onExportImage,
   onExportData,
   onExportConfig,
+  onExportMap,
   onSaveMap,
   show,
   onClose
@@ -182,6 +183,13 @@ export const SaveExportDropdown = ({
           onClickHandler={onExportConfig}
           onClose={onClose}
           icon={(<CodeAlt height="16px" />)}
+        />
+
+        <PanelItem
+          label="Export Map"
+          onClickHandler={onExportMap}
+          onClose={onClose}
+          icon={(<Map height="16px" />)}
         />
 
         {onSaveMap ? (
@@ -232,6 +240,7 @@ function PanelHeaderFactory() {
         onExportImage,
         onExportData,
         onExportConfig,
+        onExportMap,
         visibleDropdown,
         showExportDropdown,
         hideExportDropdown
@@ -262,6 +271,7 @@ function PanelHeaderFactory() {
                       onExportData={onExportData}
                       onExportImage={onExportImage}
                       onExportConfig={onExportConfig}
+                      onExportMap={onExportMap}
                     />
                   ) : null}
                 </div>

--- a/src/components/side-panel/panel-header.js
+++ b/src/components/side-panel/panel-header.js
@@ -83,6 +83,7 @@ const StyledPanelDropdown = styled.div`
   font-size: 11px;
   padding: 16px 0;
   position: absolute;
+  left: 64px;
   transition: ${props => props.theme.transitionSlow};
   display: flex;
   margin-top: ${props => props.show ? '6px' : '20px'};

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -128,6 +128,9 @@ const ActionTypes = keyMirror({
   SET_EXPORT_FILTERED: null,
   SET_EXPORT_DATA: null,
 
+  // uiState > export html
+  SET_EXPORT_MAPBOX_ACCESS_TOKEN: null,
+
   // all
   INIT: null,
   ADD_DATA_TO_MAP: null,

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -74,6 +74,13 @@ export const EXPORT_CONFIG_ID = 'exportConfig';
  * @public
  */
 export const ADD_MAP_STYLE_ID = 'addMapStyle';
+/**
+ * Modal id: export map modal
+ * @constant
+ * @type {string}
+ * @public
+ */
+export const EXPORT_MAP_ID = 'exportMap';
 
 import {
   Layers,

--- a/src/constants/user-guides.js
+++ b/src/constants/user-guides.js
@@ -1,0 +1,2 @@
+export const GITHUB_EXPORT_HTML_MAP = 'https://github.com/uber/kepler.gl/blob/master/docs/user-guides/k-save-and-export.md#2save-and-export-current-map';
+export const MAPBOX_ACCESS_TOKEN = 'https://docs.mapbox.com/help/how-mapbox-works/access-tokens/';

--- a/src/reducers/ui-state-updaters.js
+++ b/src/reducers/ui-state-updaters.js
@@ -140,7 +140,25 @@ export const DEFAULT_EXPORT_DATA = {
   data: false // this is used in modal config export
 };
 
+/**
+ * @constant
+ * @type {Array}
+ */
 export const DEFAULT_NOTIFICATIONS = [];
+
+/**
+ * @constant
+ * @type {Object}
+ * @property {string} exportMapboxAccessToken - Default: null,
+ * @property {string} dataType - Default: 'csv',
+ * @property {boolean} filtered - Default: true,
+ * @property {boolean} config - deprecated
+ * @property {boolean} data - used in modal config expor. Default: falset
+ * @public
+ */
+export const DEFAULT_EXPORT_HTML = {
+  exportMapboxAccessToken: ''
+};
 
 /**
  * Default initial `uiState`
@@ -167,6 +185,8 @@ export const INITIAL_UI_STATE = {
   exportImage: DEFAULT_EXPORT_IMAGE,
   // export data modal ui
   exportData: DEFAULT_EXPORT_DATA,
+  // html export
+  exportHtml: DEFAULT_EXPORT_HTML,
   // map control panels
   mapControls: DEFAULT_MAP_CONTROLS,
   // ui notifications
@@ -437,7 +457,7 @@ export const setExportFilteredUpdater = (state, {payload: filtered}) => ({
  * @returns {Object} nextState
  * @public
  */
-export const setExportDataUpdater = (state, action) => ({
+export const setExportDataUpdater = state => ({
   ...state,
   exportData: {
     ...state.exportData,
@@ -446,14 +466,30 @@ export const setExportDataUpdater = (state, action) => ({
 });
 
 /**
- * Add a notification to be displayed
- * @memberof uiStateUpdaters
- * @param {Object} state `uiState`
+ * whether to export a mapbox access to HTML single page
+ * @param {Object} state - `uiState`
  * @param {Object} action
- * @param {Object} action.payload
+ * @param {string} action.payload
  * @returns {Object} nextState
  * @public
  */
+export const setExportMapboxAccessTokenUpdater = (state, {payload: exportMapboxAccessToken}) => ({
+  ...state,
+  exportHtml: {
+    ...state.exportHtml,
+    exportMapboxAccessToken
+  }
+});
+
+/**
+* Add a notification to be displayed
+* @memberof uiStateUpdaters
+* @param {Object} state `uiState`
+* @param {Object} action
+* @param {Object} action.payload
+* @returns {Object} nextState
+* @public
+*/
 export const addNotificationUpdater = (state, {payload}) => ({
   ...state,
   notifications: [

--- a/src/reducers/ui-state.js
+++ b/src/reducers/ui-state.js
@@ -46,7 +46,8 @@ const actionHandler = {
   [ActionTypes.SET_EXPORT_SELECTED_DATASET]: uiStateUpdaters.setExportSelectedDatasetUpdater,
   [ActionTypes.SET_EXPORT_DATA_TYPE]: uiStateUpdaters.setExportDataTypeUpdater,
   [ActionTypes.SET_EXPORT_FILTERED]: uiStateUpdaters.setExportFilteredUpdater,
-  [ActionTypes.SET_EXPORT_DATA]: uiStateUpdaters.setExportDataUpdater
+  [ActionTypes.SET_EXPORT_DATA]: uiStateUpdaters.setExportDataUpdater,
+  [ActionTypes.SET_EXPORT_MAPBOX_ACCESS_TOKEN]: uiStateUpdaters.setExportMapboxAccessTokenUpdater
 };
 
 /* Reducer */

--- a/src/styles/base.js
+++ b/src/styles/base.js
@@ -185,6 +185,7 @@ export const modalTitleColor = '#3A414C';
 export const modalTitleFontSize = '24px';
 export const modalFooterBgd = '#F8F8F9';
 export const modalImagePlaceHolder = '#DDDFE3';
+export const modalPadding = '10px 0';
 
 // Modal Dialog (Dark)
 export const modalDialogBgd = '#3A414C';
@@ -849,6 +850,7 @@ export const theme = {
   modalTitleFontSize,
   modalFooterBgd,
   modalImagePlaceHolder,
+  modalPadding,
 
   modalDialogBgd,
   modalDialogColor,

--- a/src/templates/export-map.js
+++ b/src/templates/export-map.js
@@ -58,7 +58,7 @@ export const exportMapToHTML = options => {
         const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken, warningMessage) {
           
           /* Validate Mapbox Token */
-          if ((mapboxToken || '') === '' || mapboxToken === 'PROVIDE_MAPBOX_TOKEN') {
+          if ((mapboxToken || '') === '') {
             alert(warningMessage)
           }
           

--- a/src/templates/export-map.js
+++ b/src/templates/export-map.js
@@ -43,9 +43,8 @@ export const exportMapToHTML = options => {
          * Provide your MapBox Token
          * This will be used in app.js (imported later)
          * */
-        const MAPBOX_TOKEN = 'PROVIDE_MAPBOX_TOKEN';
+        const MAPBOX_TOKEN = '${options.mapboxApiAccessToken || 'PROVIDE_MAPBOX_TOKEN'}';
       </script>
-    
     </head>
     <body>
       <!-- We will put our React component inside this div. -->

--- a/src/templates/export-map.js
+++ b/src/templates/export-map.js
@@ -44,6 +44,7 @@ export const exportMapToHTML = options => {
          * This will be used in app.js (imported later)
          * */
         const MAPBOX_TOKEN = '${options.mapboxApiAccessToken || 'PROVIDE_MAPBOX_TOKEN'}';
+        const WARNING_MESSAGE = 'Please Provide a Mapbox Token in order to use Kepler.gl. Edit this file and fill out MAPBOX_TOKEN with your access key';
       </script>
     </head>
     <body>
@@ -54,7 +55,13 @@ export const exportMapToHTML = options => {
     
       <!-- Load our React component. -->
       <script>
-        const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken) {
+        const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken, warningMessage) {
+          
+          /* Validate Mapbox Token */
+          if ((mapboxToken || '') === '' || mapboxToken === 'PROVIDE_MAPBOX_TOKEN') {
+            alert(warningMessage)
+          }
+          
           /** STORE **/
           const reducers = redux.combineReducers({
             // mount keplerGl reducer
@@ -106,7 +113,7 @@ export const exportMapToHTML = options => {
           };
     
           /** END COMPONENTS **/
-        }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN));
+        }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN, WARNING_MESSAGE));
     
         // Render kepler in the html page
         map.render();

--- a/src/templates/export-map.js
+++ b/src/templates/export-map.js
@@ -1,0 +1,136 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export const exportMapToHTML = options => {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="UTF-8"/>
+      <title>Kepler.gl embedded map</title>
+    
+      <!-- Load React/Redux -->
+      <script src="https://unpkg.com/react@15.6.2/dist/react.min.js" crossorigin></script>
+      <script src="https://unpkg.com/react-dom@15.6.2/dist/react-dom.min.js" crossorigin></script>
+      <script src="https://unpkg.com/redux@3.7.2/dist/redux.js" crossorigin></script>
+      <script src="https://unpkg.com/react-redux@4.4.9/dist/react-redux.min.js" crossorigin></script>
+    
+      <!-- Load Kepler.gl latest version-->
+      <script src="https://unpkg.com/kepler.gl/umd/keplergl.min.js"></script>
+      <!-- You can also specify a specific versions by doing the following -->
+      <!--<script src="https://unpkg.com/kepler.gl@0.2.2/umd/keplergl.min.js"></script>-->
+    
+      <!--MapBox token-->
+      <script>
+        /**
+         * Provide your MapBox Token
+         * This will be used in app.js (imported later)
+         * */
+        const MAPBOX_TOKEN = 'PROVIDE_MAPBOX_TOKEN';
+      </script>
+    
+    </head>
+    <body>
+      <!-- We will put our React component inside this div. -->
+      <div id="app">
+        <!-- Kepler.gl map will be placed here-->
+      </div>
+    
+      <!-- Load our React component. -->
+      <script>
+        const map = (function initKeplerGl(react, reactDOM, redux, reactRedux, keplerGl, mapboxToken) {
+          /** STORE **/
+          const reducers = redux.combineReducers({
+            // mount keplerGl reducer
+            keplerGl: keplerGl.keplerGlReducer
+          });
+    
+          const middlewares = keplerGl.enhanceReduxMiddleware([
+            // Add other middlewares here
+          ]);
+    
+          const enhancers = redux.applyMiddleware(...middlewares);
+    
+          const initialState = {};
+    
+          const store = redux.createStore(
+            reducers,
+            initialState,
+            redux.compose(enhancers)
+          );
+          /** END STORE **/
+    
+          /** COMPONENTS **/
+          function App(props) {
+            return react.createElement(
+              'div',
+              {style: {position: 'absolute', left: 0, width: '100vw', height: '100vh'}},
+              react.createElement(
+                keplerGl.KeplerGl,
+                {
+                  mapboxApiAccessToken: mapboxToken,
+                  id: 'map',
+                  width: props.width || 1200,
+                  height: props.height || 800
+                }
+              )
+            )
+          }
+    
+          return {
+            render: () => {
+              reactDOM.render(react.createElement(
+                reactRedux.Provider,
+                {store},
+                react.createElement(App, null)
+              ), document.getElementById('app'));
+            },
+            // By returning store we can interact with the map, e.g. add data
+            store
+          };
+    
+          /** END COMPONENTS **/
+        }(React, ReactDOM, Redux, ReactRedux, KeplerGl, MAPBOX_TOKEN));
+    
+        // Render kepler in the html page
+        map.render();
+      </script>
+      <!-- The next script will show how to interact directly with Kepler map store -->
+      <script>
+        /**
+         * Customize map.
+         * Interact with map store to customize data and behavior
+         */
+        (function customize(keplerGl, map) {
+          const datasets = ${JSON.stringify(options.datasets)};
+          const config = ${JSON.stringify(options.config)};
+          
+          const loadedData = keplerGl.KeplerGlSchema.load(
+            datasets,
+            config
+          );
+          
+          map.store.dispatch(keplerGl.addDataToMap(loadedData));
+        }(KeplerGl, map))
+      </script>
+    </body>
+    </html>
+  `;
+};

--- a/src/templates/export-map.js
+++ b/src/templates/export-map.js
@@ -52,8 +52,7 @@ export const exportMapToHTML = options => {
       <script>
         /**
          * Provide your MapBox Token
-         * This will be used in app.js (imported later)
-         * */
+         **/
         const MAPBOX_TOKEN = '${options.mapboxApiAccessToken || 'PROVIDE_MAPBOX_TOKEN'}';
         const WARNING_MESSAGE = 'Please Provide a Mapbox Token in order to use Kepler.gl. Edit this file and fill out MAPBOX_TOKEN with your access key';
       </script>

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -124,7 +124,11 @@ const COMMON_CONFIG = {
 
   // Optional: Enables reading mapbox token from environment variable
   plugins: [
-    new webpack.EnvironmentPlugin(['MapboxAccessToken', 'DropboxClientId'])
+    new webpack.EnvironmentPlugin([
+      'MapboxAccessToken',
+      'DropboxClientId',
+      'MapboxExportToken'
+    ])
   ]
 };
 
@@ -179,6 +183,18 @@ module.exports = env => {
       logInstruction(`Make sure to run "export MapboxAccessToken=<token>" before deploy the website`);
       logInstruction('You can get the token at https://www.mapbox.com/help/how-access-tokens-work/');
       throw new Error('Missing Mapbox Access token');
+    }
+    if (!process.env.MapboxAccessToken) {
+      logError('Error! DropboxClientId is not defined');
+      logInstruction(`Make sure to run "export MapboxExportToken=<token>" before deploy the website`);
+      logInstruction('You can get the token at https://www.dropbox.com/developers');
+      throw new Error('Missing Export DropboxClientId Access token');
+    }
+    if (!process.env.MapboxAccessToken) {
+      logError('Error! MapboxExportToken is not defined');
+      logInstruction(`Make sure to run "export MapboxExportToken=<token>" before deploy the website`);
+      logInstruction('You can get the token at https://www.mapbox.com/help/how-access-tokens-work/');
+      throw new Error('Missing Export Mapbox Access token, used to generate the single map file');
     }
     config = addProdConfig(config);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,8 +1411,8 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
 async-each@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.2.tgz#8b8a7ca2a658f927e9f307d6d1a42f4199f0f735"
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -1992,8 +1992,8 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
 
 caniuse-lite@^1.0.30000939:
-  version "1.0.30000946"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000946.tgz#ac50a3331bb805b483478bbc26a0ab71bb6d0509"
+  version "1.0.30000947"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000947.tgz#c30305e9701449c22e97f4e9837cea3d76aa3273"
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -3061,8 +3061,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.113:
-  version "1.3.115"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.115.tgz#fdaa56c19b9f7386dbf29abc1cc632ff5468ff3b"
+  version "1.3.116"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.116.tgz#1dbfee6a592a0c14ade77dbdfe54fef86387d702"
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -3117,8 +3117,8 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
 
 enzyme-adapter-react-16@^1.10.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.0.tgz#cf9c60ea0d98be713e92cc7100ef99dd29c5f33f"
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.1.tgz#f4b39595e85701449089f85ad9575ec0fa36f677"
   dependencies:
     enzyme-adapter-utils "^1.10.1"
     object.assign "^4.1.0"
@@ -3352,8 +3352,8 @@ eslint@^5.12.1:
     text-table "^0.2.0"
 
 esm@^3.0.84:
-  version "3.2.16"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.16.tgz#e48f887c29a4a981a4da0baa2ae2bf20e30b5614"
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.17.tgz#ae74c34f502ab2ee8f03c64cc785ebeb1786526a"
 
 espree@^5.0.1:
   version "5.0.1"
@@ -5772,8 +5772,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.9.2:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.0.tgz#7bdfc27dd3c060c46e60b62c72b74012d1a4cd68"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6911,8 +6911,8 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react-map-gl@^4.0.14:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-4.0.15.tgz#74afb75e8d7d0d135fa15d688a7c7790c937703c"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-4.1.0.tgz#99729e59dcd2fad16c35d8db290adcd72772c864"
   dependencies:
     "@babel/runtime" "^7.0.0"
     mapbox-gl "~0.53.0"


### PR DESCRIPTION
This diff provides the feature to export current Kepler.gl Map onto a single html map with both data and configuration along with necessary javascript dependency.

![single-page-map](https://user-images.githubusercontent.com/2554552/53145116-d98d8900-3553-11e9-8f96-be35ea1999d9.gif)

This is one of the possible UX solution.

### Alternative
We could merge some of the export options into a single modal and use tabs or other UX elements to switch between different export capabilities.
