### PR TITLE
[Feat] Add getMapboxRef prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ version displayed in side panel header
 
 Action called when click Save Map Url in side panel header.
 
+##### `getMapboxRef(mapbox, index)` (Function, optional)
+
+- Default: `undefined`
+
+Function called when `KeplerGL` adds or removes a `MapContainer` component having an inner Mapbox map.
+
+The `mapbox` argument is an [`InteractiveMap`](https://uber.github.io/react-map-gl/#/Documentation/api-reference/interactive-map) when added or `null` when removed.
+
+The `index` argument is 0 for a single map or 1 for an additional map (since `KeplerGL` supports an optional split map view).
+
 ##### `actions` (Object, optional)
 
 - Default: `{}`

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -285,6 +285,15 @@ class App extends Component {
     this.props.dispatch(setCloudLoginSuccess());
   };
 
+  _getMapboxRef = mapbox => {
+    // We expect 'mapbox' to be an InteractiveMap created by KeplerGl's MapContainer.
+    // https://uber.github.io/react-map-gl/#/Documentation/api-reference/interactive-map
+    const map = mapbox.getMap();
+    map.on('zoomend', e => {
+      // console.log(`Zoom level: ${e.target.style.z}`);
+    });
+  };
+
   render() {
     const {showBanner, width, height} = this.state;
     const {sharing} = this.props.demo;
@@ -336,6 +345,7 @@ class App extends Component {
               width={width}
               height={height - (showBanner ? BannerHeight : 0)}
               onSaveMap={this._isCloudStorageEnabled() && this._toggleCloudModal}
+              getMapboxRef={this._getMapboxRef}
             />
           </div>
         </GlobalStyle>

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -285,13 +285,19 @@ class App extends Component {
     this.props.dispatch(setCloudLoginSuccess());
   };
 
-  _getMapboxRef = mapbox => {
-    // We expect 'mapbox' to be an InteractiveMap created by KeplerGl's MapContainer.
-    // https://uber.github.io/react-map-gl/#/Documentation/api-reference/interactive-map
-    const map = mapbox.getMap();
-    map.on('zoomend', e => {
-      // console.log(`Zoom level: ${e.target.style.z}`);
-    });
+  _getMapboxRef = (mapbox, index) => {
+    if (!mapbox) {
+      // The ref has been unset.
+      // https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+      // console.log(`Map ${index} has closed`);
+    } else {
+      // We expect an InteractiveMap created by KeplerGl's MapContainer.
+      // https://uber.github.io/react-map-gl/#/Documentation/api-reference/interactive-map
+      const map = mapbox.getMap();
+      map.on('zoomend', e => {
+        // console.log(`Map ${index} zoom level: ${e.target.style.z}`);
+      });
+    }
   };
 
   render() {

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -152,6 +152,14 @@ function KeplerGlFactory(
       );
     };
 
+    _getMapboxRef = mapbox => {
+      if (this.props.getMapboxRef) {
+        // The parent component can gain access to our MapContainer's
+        // InteractiveMap by providing this callback.
+        this.props.getMapboxRef(mapbox);
+      }
+    };
+
     _requestMapStyle = (mapStyle) => {
       const {url, id} = mapStyle;
 
@@ -260,6 +268,7 @@ function KeplerGlFactory(
               index={0}
               {...mapFields}
               mapLayers={isSplit ? splitMaps[0].layers : null}
+              getMapboxRef={this._getMapboxRef}
             />
           ]
         : splitMaps.map((settings, index) => (
@@ -268,6 +277,7 @@ function KeplerGlFactory(
               index={index}
               {...mapFields}
               mapLayers={splitMaps[index].layers}
+              getMapboxRef={this._getMapboxRef}
             />
           ));
 

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -152,14 +152,6 @@ function KeplerGlFactory(
       );
     };
 
-    _getMapboxRef = mapbox => {
-      if (this.props.getMapboxRef) {
-        // The parent component can gain access to our MapContainer's
-        // InteractiveMap by providing this callback.
-        this.props.getMapboxRef(mapbox);
-      }
-    };
-
     _requestMapStyle = (mapStyle) => {
       const {url, id} = mapStyle;
 
@@ -187,6 +179,7 @@ function KeplerGlFactory(
         width,
         height,
         mapboxApiAccessToken,
+        getMapboxRef,
 
         // redux state
         mapStyle,
@@ -268,7 +261,7 @@ function KeplerGlFactory(
               index={0}
               {...mapFields}
               mapLayers={isSplit ? splitMaps[0].layers : null}
-              getMapboxRef={this._getMapboxRef}
+              getMapboxRef={getMapboxRef}
             />
           ]
         : splitMaps.map((settings, index) => (
@@ -277,7 +270,7 @@ function KeplerGlFactory(
               index={index}
               {...mapFields}
               mapLayers={splitMaps[index].layers}
-              getMapboxRef={this._getMapboxRef}
+              getMapboxRef={getMapboxRef}
             />
           ));
 

--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -86,7 +86,8 @@ export default function MapContainerFactory(MapPopover, MapControl) {
       mapLayers: PropTypes.object,
       onMapToggleLayer: PropTypes.func,
       onMapStyleLoaded: PropTypes.func,
-      onMapRender: PropTypes.func
+      onMapRender: PropTypes.func,
+      getMapboxRef: PropTypes.func
     };
 
     static defaultProps = {
@@ -149,12 +150,6 @@ export default function MapContainerFactory(MapPopover, MapControl) {
     _setMapboxMap = (mapbox) => {
       if (!this._map && mapbox) {
 
-        if (this.props.getMapboxRef) {
-          // The parent component can gain access to our MapboxGlMap by
-          // providing this callback.
-          this.props.getMapboxRef(mapbox);
-        }
-
         this._map = mapbox.getMap();
         // bind mapboxgl event listener
         this._map.on(MAPBOXGL_STYLE_UPDATE, () => {
@@ -178,6 +173,13 @@ export default function MapContainerFactory(MapPopover, MapControl) {
             this.props.onMapRender(this._map);
           }
         });
+      }
+
+      if (this.props.getMapboxRef) {
+        // The parent component can gain access to our MapboxGlMap by
+        // providing this callback. Note that 'mapbox' will be null when the
+        // ref is unset (e.g. when a split map is closed).
+        this.props.getMapboxRef(mapbox, this.props.index);
       }
     }
 

--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -148,6 +148,13 @@ export default function MapContainerFactory(MapPopover, MapControl) {
 
     _setMapboxMap = (mapbox) => {
       if (!this._map && mapbox) {
+
+        if (this.props.getMapboxRef) {
+          // The parent component can gain access to our MapboxGlMap by
+          // providing this callback.
+          this.props.getMapboxRef(mapbox);
+        }
+
         this._map = mapbox.getMap();
         // bind mapboxgl event listener
         this._map.on(MAPBOXGL_STYLE_UPDATE, () => {


### PR DESCRIPTION
Adds a `getMapboxRef` prop which you can set to your custom function. That function is passed down into KeplerGl's MapContainer and is used as a callback to expose the MapContainer's `react-map-gl` [InteractiveMap](https://uber.github.io/react-map-gl/#/Documentation/api-reference/interactive-map) instance. In other words, `getMapboxRef` gives KeplerGl's parent component a reference to the inner Mapbox map.

Is this a good pattern or an anti-pattern? See my update to `examples/demo-app/src/app.js` on how it would be used.

See #268. Exposing access to the full [Mapbox GL API](https://docs.mapbox.com/mapbox-gl-js/api/) should also open a solution for #293 and #118.

Kepler.gl has powerful client-side visualizations for GeoJSON. By having access to the Mapbox GL API, developers can easily add [raster](https://docs.mapbox.com/mapbox-gl-js/example/map-tiles/) and vector layers from a variety of sources, and further customize map interactions.