### PR TITLE
Replaced DI object storage with an actual Map

### DIFF
--- a/examples/demo-app/src/factories/save-map.js
+++ b/examples/demo-app/src/factories/save-map.js
@@ -31,4 +31,4 @@ export const CustomSaveMapFactory = () => {
 
 export function replaceSaveMap() {
   return [SaveMapFactory, CustomSaveMapFactory]
-};
+}

--- a/src/components/injector.js
+++ b/src/components/injector.js
@@ -32,10 +32,11 @@ export const errorMsg = {
   notFunc: '`factory and its replacement should be a function`'
 };
 
-export function injector(map = {}) {
-  const cache = {}; // map<factory, factory -> ?>
+export function injector(map = new Map()) {
+  const cache = new Map(); // map<factory, factory -> ?>
   const get = (fac, parent) => {
-    const factory = map[fac];
+    const factory = map.get(fac);
+
     // factory is not injected
     if (!factory) {
       Console.error(errorMsg.noDep(fac, parent));
@@ -43,12 +44,12 @@ export function injector(map = {}) {
     }
 
     const instances =
-      cache[factory] ||
+      cache.get(factory) ||
       factory(
         ...(factory.deps ? factory.deps.map(dep => get(dep, factory)) : [])
       );
 
-    cache[fac] = instances;
+    cache.set(fac, instances);
     return instances;
   };
 
@@ -66,7 +67,7 @@ export function injector(map = {}) {
         return injector(map);
       }
 
-      return injector({...map, [factory]: replacement});
+      return injector((new Map(map)).set(factory, replacement));
     },
     get
   };

--- a/src/components/modals/export-config-modal.js
+++ b/src/components/modals/export-config-modal.js
@@ -136,4 +136,5 @@ const ExportConfigModal = ({
 ExportConfigModal.propTypes = propTypes;
 
 const ExportConfigModalFactory = () => ExportConfigModal;
+
 export default ExportConfigModalFactory;

--- a/src/components/modals/export-map-modal.js
+++ b/src/components/modals/export-map-modal.js
@@ -97,5 +97,6 @@ const ExportMapModal = ({
 
 ExportMapModal.propTypes = propTypes;
 
-const exportMapModalFactory = () => ExportMapModal;
-export default exportMapModalFactory;
+const ExportMapModalFactory = () => ExportMapModal;
+
+export default ExportMapModalFactory;


### PR DESCRIPTION
As part of the DI process we store factories in an object using the function/factory itself as key.

We noticed after code is minified we had an issue where two different components, which are part of DI chain, where returning the exactly same element.

After troubleshooting the problem we found an issue with the way we are storing factories as part of DI process. We are currently using an obj to store all factories, but we are also using factories as key. When a function is used as key, javascript calls toString() method on the function and such . value will be used as key.
During the minification process we realized both components have the same two string value: 
```
f() {return g}: 
```
a oddly coincidence.

I solved the issue by replacing the DI storage obj with an actual __Map__. The advantage of using a Map is the way the structure handle functions as key; in fact when functions are passed as keys Map will use Symbol to generate a unique identifier [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)