### PR TITLE
[Feat] Add a light theme to KeplerGl Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ By Parsing `mint: false` kepler.gl will keep the component state in the store ev
 
 Read more about [Components][components].
 
-##### `theme` (Object, optional)
+##### `theme` (Object | String, optional)
 
 - default: `null`
 
-Object used to customize Kepler.gl style. Kepler.gl will use the value passed as input to override values from [theme](https://github.com/uber/kepler.gl/blob/master/src/styles/base.js).
+You can pass theme name or object used to customize Kepler.gl style. Kepler.gl provide an `'light'` theme besides the default 'dark' theme. When pass in a theme object Kepler.gl will use the value passed as input to override values from [theme](https://github.com/uber/kepler.gl/blob/master/src/styles/base.js).
 
 ### 3. Dispatch custom actions to `keplerGl` reducer.
 
@@ -358,7 +358,7 @@ return (
   />
 );
 
-``` 
+```
 As you can see the customTheme object defines certain properties which will override Kepler.gl default style rules.
 
 #### Styled-Components Theme Provider.
@@ -382,9 +382,9 @@ return (
       width={800}
       height={800}
     />
-  </ThemeProvider>  
+  </ThemeProvider>
 );
-``` 
+```
 
 ### 5. Render Custom UI components.
 Everyone wants the flexibility to render custom kepler.gl components. Kepler.gl has a dependency injection system that allow you to inject

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -99,6 +99,7 @@ function KeplerGlFactory(
       height: 800,
       appName: KEPLER_GL_NAME,
       version: KEPLER_GL_VERSION,
+      sidePanelWidth: DIMENSIONS.sidePanel.width,
       theme: {}
     };
 
@@ -221,7 +222,7 @@ function KeplerGlFactory(
         mapStyleActions,
         visStateActions,
         uiStateActions,
-        width: DIMENSIONS.sidePanel.width
+        width: this.props.sidePanelWidth
       };
 
       const mapFields = {
@@ -305,7 +306,7 @@ function KeplerGlFactory(
               uiState={uiState}
               visStateActions={visStateActions}
               sidePanelWidth={
-                uiState.readOnly ? 0 : DIMENSIONS.sidePanel.width + DIMENSIONS.sidePanel.margin.left
+                uiState.readOnly ? 0 : this.props.sidePanelWidth + DIMENSIONS.sidePanel.margin.left
               }
               containerW={containerW}
             />

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -31,7 +31,7 @@ import * as MapStyleActions from 'actions/map-style-actions';
 import * as UIStateActions from 'actions/ui-state-actions';
 
 import {EXPORT_IMAGE_ID, DIMENSIONS,
-  KEPLER_GL_NAME, KEPLER_GL_VERSION} from 'constants/default-settings';
+  KEPLER_GL_NAME, KEPLER_GL_VERSION, THEME} from 'constants/default-settings';
 
 import SidePanelFactory from './side-panel';
 import MapContainerFactory from './map-container';
@@ -42,7 +42,7 @@ import NotificationPanelFactory from './notification-panel';
 
 import {generateHashId} from 'utils/utils';
 
-import {theme as basicTheme} from 'styles/base';
+import {theme as basicTheme, themeLT} from 'styles/base';
 
 // Maybe we should think about exporting this or creating a variable
 // as part of the base.js theme
@@ -124,10 +124,10 @@ function KeplerGlFactory(
     themeSelector = props => props.theme;
     availableThemeSelector = createSelector(
       this.themeSelector,
-      theme => ({
+      theme => typeof theme === 'object' ? ({
         ...basicTheme,
         ...theme
-      })
+      }) : theme === THEME.light ? themeLT : theme
     );
 
     _handleResize({width, height}) {

--- a/src/components/map/map-control.js
+++ b/src/components/map/map-control.js
@@ -107,7 +107,7 @@ const StyledMapControlPanelHeader = styled.div`
   height: 32px;
   padding: 6px 12px;
   font-size: 11px;
-  color: ${props => props.theme.secondaryBtnColor};
+  color: ${props => props.theme.titleTextColor};
 
   button {
     width: 18px;

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -105,6 +105,17 @@ export const DIMENSIONS = {
   }
 };
 
+/**
+ * Theme name that can be passed to `KeplerGl` `prop.theme`.
+ * Available themes are `Theme.light` and `Theme.dark`. Default theme is `Theme.dark`
+ * @constant
+ * @type {string}
+ * @public
+ * @example
+ * ```js
+ * const Map = () => <KeplerGl theme={THEME.light} id="map"/>
+ * ```
+ */
 export const THEME = keyMirror({
   light: null,
   dark: null

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -105,6 +105,11 @@ export const DIMENSIONS = {
   }
 };
 
+export const THEME = keyMirror({
+  light: null,
+  dark: null
+});
+
 export const PANELS = [
   {
     id: 'layer',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -41,7 +41,8 @@ export {
   EXPORT_CONFIG_ID,
   ADD_MAP_STYLE_ID,
   DEFAULT_LAYER_GROUPS,
-  DEFAULT_MAP_STYLES
+  DEFAULT_MAP_STYLES,
+  THEME
 } from './default-settings';
 export {VizColorPalette, DataVizColors} from './custom-color-ranges';
 export {COLOR_RANGES, DefaultColorRange} from './color-ranges';

--- a/src/styles/base.js
+++ b/src/styles/base.js
@@ -920,7 +920,29 @@ export const themeLT = {
 
   // template
   input: inputLT,
-  panelActiveBg: panelActiveBgLT,
   textColor: textColorLT,
-  textColorHl: textColorHlLT
+  sidePanelBg: '#ffffff',
+  titleTextColor: '#000000',
+  sidePanelHeaderBg: '#f7f7F7',
+  subtextColorActive: '#2473bd',
+  tooltipBg: '#1869b5',
+  tooltipColor: '#ffffff',
+  dropdownListBgd: '#ffffff',
+  textColorHl: '#2473bd',
+  inputBgd: '#f7f7f7',
+  inputBgdHover: '#ffffff',
+  inputBgdActive: '#ffffff',
+  dropdownListHighlightBg: '#f0f0f0',
+  panelBackground: '#f7f7F7',
+  panelBackgroundHover: '#f7f7F7',
+  panelBorderColor: '#D3D8E0',
+  secondaryInputBgd: '#f7f7F7',
+  secondaryInputBgdActive: '#f7f7F7',
+  secondaryInputBgdHover: '#ffffff',
+  panelActiveBg: '#f7f7F7',
+  mapPanelBackgroundColor: '#ffffff',
+  mapPanelHeaderBackgroundColor: '#f7f7F7',
+  sliderBarBgd: '#D3D8E0',
+  secondarySwitchBtnBgd: '#D3D8E0',
+  switchTrackBgd: '#D3D8E0'
 };


### PR DESCRIPTION
- Allow passing `theme: 'light'` to `KeplerGl` component

![Screen Shot 2019-04-22 at 6 21 52 PM](https://user-images.githubusercontent.com/3605556/56545177-950a7380-652b-11e9-9cc1-498791d8ecb9.png)
